### PR TITLE
docs: update main page info

### DIFF
--- a/docs/api/remote-procedure-call-quick-reference.md
+++ b/docs/api/remote-procedure-call-quick-reference.md
@@ -1,3 +1,7 @@
+```{eval-rst}
+.. _api-rpc-quick-reference:
+```
+
 # Quick Reference
 
 ## [Addressindex RPCs](../api/remote-procedure-calls-address-index.md)

--- a/docs/api/remote-procedure-calls.md
+++ b/docs/api/remote-procedure-calls.md
@@ -1,3 +1,7 @@
+```{eval-rst}
+.. _api-rpc:
+```
+
 # Remote Procedure Calls
 
 ## Overview

--- a/docs/dashcore/wallet-arguments-and-commands.md
+++ b/docs/dashcore/wallet-arguments-and-commands.md
@@ -1,3 +1,7 @@
+```{eval-rst}
+.. _dashcore-arguments-and-commands:
+```
+
 # Arguments and Commands
 
 ## Overview

--- a/docs/examples/introduction.md
+++ b/docs/examples/introduction.md
@@ -1,3 +1,7 @@
+```{eval-rst}
+.. _examples-index:
+```
+
 # Introduction
 
 The following guide aims to provide examples to help you start building Dash-based applications. To make the best use of this document, you may want to install the current version of Dash Core, either from [source](https://github.com/dashpay/dash/) or from a [pre-compiled executable](https://www.dash.org/wallets/#wallets).

--- a/docs/guide/introduction.md
+++ b/docs/guide/introduction.md
@@ -1,3 +1,7 @@
+```{eval-rst}
+.. _guide-index:
+```
+
 # Introduction
 
 The Developer Guide aims to provide the information you need to understand Dash and start building Dash-based applications, but it is not a specification. To make the best use of this documentation, you may want to install the current version of Dash Core, either from [source](https://github.com/dashpay/dash/) or from a [pre-compiled executable](https://www.dash.org/wallets/#wallets).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,26 @@
 # Core docs
 
+Welcome to the Dash Core developer documentation. You'll find guides and
+documentation to help you start working with Dash Core as quickly as possible,
+as well as support if you get stuck. Let's jump right in!
+
+Questions about Dash development are best asked in one of the [Dash development
+communities](https://www.dash.org/community/). Errors or suggestions related to
+documentation can be submitted as via the "Suggest Edits" button on the top,
+right of each page.
+
+```{eval-rst}
+.. raw:: html
+
+    <div style="position: relative; padding-bottom: 56.25%; height: 0; margin-bottom: 1em; overflow: hidden; max-width: 70%; height: auto;">
+        <iframe src="//www.youtube.com/embed/EDC1ioQ46m4" frameborder="0" allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe>
+    </div>
+```
+
 ```{toctree}
 :maxdepth: 2
 :caption: Core Reference
+:hidden:
 
 reference/introduction
 reference/block-chain
@@ -16,6 +34,7 @@ reference/improvement-proposals
 :maxdepth: 2
 :titlesonly:
 :caption: Core API Reference
+:hidden:
 
 api/dash-core-apis-hash-byte-order
 api/remote-procedure-calls
@@ -27,6 +46,7 @@ api/zmq
 :maxdepth: 2
 :caption: Core Guides
 :titlesonly:
+:hidden:
 
 guide/introduction
 guide/dash-features
@@ -42,6 +62,7 @@ guide/mining
 ```{toctree}
 :maxdepth: 2
 :caption: Core Examples
+:hidden:
 
 examples/introduction
 examples/configuration-file
@@ -55,6 +76,7 @@ examples/receiving-zmq-notifications
 :maxdepth: 2
 :titlesonly: 
 :caption: Dash Core Wallet
+:hidden:
 
 dashcore/wallet-arguments-and-commands
 dashcore/wallet-configuration-file
@@ -64,6 +86,7 @@ dashcore/wallet-configuration-file
 :maxdepth: 2
 :titlesonly:
 :caption: Additional Resources
+:hidden:
 
 resources/glossary
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,6 +17,68 @@ documentation can be submitted as via the "Suggest Edits" button on the top,
 right of each page.
 
 ```{eval-rst}
+.. grid:: 1 3 3 3
+
+    .. grid-item-card:: 🛠 Core Reference
+        :margin: 2 2 auto auto
+        :link-type: ref
+        :link: reference-index
+        
+        Blockchain and protocol details 
+        
+        +++
+        :ref:`Click to begin <reference-index>`
+
+    .. grid-item-card:: ⚡ API Reference
+        :margin: 2 2 auto auto
+        :link-type: ref
+        :link: api-rpc
+        
+        RPC, REST, and ZMQ information
+        
+        +++
+        :ref:`Click to begin <api-rpc>`
+
+    .. grid-item-card:: 📑 Core Guides
+        :margin: 2 2 auto auto
+        :link-type: ref
+        :link: guide-index
+        
+        Dash features and operation
+        
+        +++
+        :ref:`Click to begin <guide-index>`
+
+    .. grid-item-card:: 🚀 Core Examples
+        :margin: 2 2 auto auto
+        :link-type: ref
+        :link: examples-index
+        
+        Examples for common use-cases
+        
+        +++
+        :ref:`Click to begin <examples-index>`
+
+    .. grid-item-card:: ⚙ Dash Core
+        :margin: 2 2 auto auto
+        :link-type: ref
+        :link: dashcore-arguments-and-commands
+        
+        Dash Core configuration and usage
+        
+        +++
+        :ref:`Click to begin <dashcore-arguments-and-commands>`
+
+    .. grid-item-card:: 📖 Glossary
+        :margin: 2 2 auto auto
+        :link-type: ref
+        :link: resources-glossary
+        
+        Important terms with definitions
+        
+        +++
+        :ref:`Click to begin <resources-glossary>`
+        
 .. raw:: html
 
     <div style="position: relative; padding-bottom: 56.25%; height: 0; margin-bottom: 1em; overflow: hidden; max-width: 70%; height: auto;">

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,9 +4,12 @@
 
 # Core docs
 
-Welcome to the Dash Core developer documentation. You'll find guides and
-documentation to help you start working with Dash Core as quickly as possible,
-as well as support if you get stuck. Let's jump right in!
+Welcome to the Dash Core developer documentation. You'll find sections for
+[reference information](reference/introduction.md), [API
+details](api/remote-procedure-call-quick-reference.md),
+[guides](guide/introduction.md), [examples](examples/introduction.md) and [Dash
+Core wallet information](dashcore/wallet-arguments-and-commands.md) to help you
+start working with Dash as quickly as possible. Let's jump right in!
 
 Questions about Dash development are best asked in one of the [Dash development
 communities](https://www.dash.org/community/). Errors or suggestions related to

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,7 @@
+```{eval-rst}
+.. _core-index:
+```
+
 # Core docs
 
 Welcome to the Dash Core developer documentation. You'll find guides and

--- a/docs/index.md
+++ b/docs/index.md
@@ -78,12 +78,6 @@ right of each page.
         
         +++
         :ref:`Click to begin <resources-glossary>`
-        
-.. raw:: html
-
-    <div style="position: relative; padding-bottom: 56.25%; height: 0; margin-bottom: 1em; overflow: hidden; max-width: 70%; height: auto;">
-        <iframe src="//www.youtube.com/embed/EDC1ioQ46m4" frameborder="0" allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe>
-    </div>
 ```
 
 ```{toctree}

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,15 +6,10 @@
 
 Welcome to the Dash Core developer documentation. You'll find sections for
 [reference information](reference/introduction.md), [API
-details](api/remote-procedure-call-quick-reference.md),
-[guides](guide/introduction.md), [examples](examples/introduction.md) and [Dash
-Core wallet information](dashcore/wallet-arguments-and-commands.md) to help you
-start working with Dash as quickly as possible. Let's jump right in!
-
-Questions about Dash development are best asked in one of the [Dash development
-communities](https://www.dash.org/community/). Errors or suggestions related to
-documentation can be submitted as via the "Suggest Edits" button on the top,
-right of each page.
+details](api/remote-procedure-calls.md), [guides](guide/introduction.md),
+[examples](examples/introduction.md) and [Dash Core wallet
+information](dashcore/wallet-arguments-and-commands.md) to help you start
+working with Dash as quickly as possible. Let's jump right in!
 
 ```{eval-rst}
 .. grid:: 1 3 3 3

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ information](dashcore/wallet-arguments-and-commands.md) to help you start
 working with Dash as quickly as possible. Let's jump right in!
 
 ```{eval-rst}
-.. grid:: 1 3 3 3
+.. grid:: 1 2 3 3
 
     .. grid-item-card:: 🛠 Core Reference
         :margin: 2 2 auto auto
@@ -147,4 +147,16 @@ dashcore/wallet-configuration-file
 :hidden:
 
 resources/glossary
+```
+
+Questions about Dash development are best asked in one of the [Dash development
+communities](https://www.dash.org/community/). Errors or suggestions related to
+documentation can be submitted as via the "Suggest Edits" button on the top,
+right of each page.
+
+```{eval-rst}
+.. image:: https://raw.githubusercontent.com/dashpay/docs/master/img/businessplan.svg
+   :class: no-scaled-link
+   :align: center
+   :width: 90%
 ```

--- a/docs/resources/glossary.md
+++ b/docs/resources/glossary.md
@@ -1,3 +1,7 @@
+```{eval-rst}
+.. _resources-glossary:
+```
+
 # Glossary
 
 ## 51 percent attack

--- a/index.md
+++ b/index.md
@@ -62,3 +62,10 @@ Check out the `official Dash website <https://www.dash.org/>`__ to learn how
 
    docs/index
 ```
+
+```{eval-rst}
+.. image:: https://raw.githubusercontent.com/dashpay/docs/master/img/businessplan.svg
+   :class: no-scaled-link
+   :align: center
+   :width: 90%
+```

--- a/index.md
+++ b/index.md
@@ -3,13 +3,23 @@
    :description: The Dash Documentation offers information and guides on Dash, the open source peer-to-peer cryptocurrency with a strong focus on the payments industry. 
    :keywords: dash, cryptocurrency, blockchain, documentation, guide, masternodes, mining, wallets, merchants, governance, instantsend, coinjoin, privatesend, x11, instant, private, secure, digital cash
 
-.. _core-index:
+==================
+Dash Documentation
+==================
 
-=========
-Core Docs
-=========
+Dash aims to be the most user-friendly and scalable payments-focused
+cryptocurrency in the world. The Dash network features instant transaction
+confirmation, double spend protection, optional privacy equal to that of
+physical cash, a self-governing, and a self-funding model driven by incentivized
+full nodes. While Dash is based on Bitcoin and compatible with many key
+components of the Bitcoin ecosystem, its two-tier network structure offers
+significant improvements in transaction speed, privacy and governance. This
+section of the documentation describes these and many more key features that set
+Dash apart in the blockchain economy.
 
-Welcome to the Dash Core developer documentation. You'll find guides and documentation to help you start working with Dash Core as quickly as possible, as well as support if you get stuck. Let's jump right in!
+Check out the `official Dash website <https://www.dash.org/>`__ to learn how
+`individuals <https://www.dash.org/individuals/>`__ and `businesses
+<https://www.dash.org/businesses/>`__ can use Dash.
 
 .. grid:: 1 3 3 3
 
@@ -26,12 +36,12 @@ Welcome to the Dash Core developer documentation. You'll find guides and documen
     .. grid-item-card:: ⚙ Core Docs
         :margin: 2 2 auto auto
         :link-type: ref
-        :link: reference-index
+        :link: core-index
         
         Find technical details about the Dash Core blockchain, along with protocol and API reference material.
         
         +++
-        :ref:`Click to begin <reference-index>`
+        :ref:`Click to begin <core-index>`
 
     .. grid-item-card:: 🚀 Platform Docs
          :margin: 2 2 auto auto


### PR DESCRIPTION
Fix some navigation inconsistency. Make [main page](https://dash-docs--18.org.readthedocs.build/projects/core/en/18/index.html) more similar to docs.dash.org and also improve the [Core docs page](https://dash-docs--18.org.readthedocs.build/projects/core/en/18/docs/index.html).