### PR TITLE
refactor: switch to referencing images locally

### DIFF
--- a/docs/examples/p2p-network-parsing-a-merkleblock.md
+++ b/docs/examples/p2p-network-parsing-a-merkleblock.md
@@ -24,43 +24,43 @@ bb3183301d7a1fb3bd174fcfa40a2b65 ... Hash #2
 
 We parse the above [`merkleblock` message](../reference/p2p-network-data-messages.md#merkleblock) using the following instructions.  Each illustration is described in the paragraph below it.
 
-![Parsing A MerkleBlock](https://raw.githubusercontent.com/dashpay/docs-core/main/img/dev/gifs/en-merkleblock-parsing/en-merkleblock-parsing-001.svg)
+![Parsing A MerkleBlock](../../img/dev/gifs/en-merkleblock-parsing/en-merkleblock-parsing-001.svg)
 
 We start by building the structure of a [merkle tree](../resources/glossary.md#merkle-tree) based on the number of [transactions](../resources/glossary.md#transaction) in the [block](../resources/glossary.md#block).
 
-![Parsing A MerkleBlock](https://raw.githubusercontent.com/dashpay/docs-core/main/img/dev/gifs/en-merkleblock-parsing/en-merkleblock-parsing-002.svg)
+![Parsing A MerkleBlock](../../img/dev/gifs/en-merkleblock-parsing/en-merkleblock-parsing-002.svg)
 
 The first flag is a 1 and the [merkle root](../resources/glossary.md#merkle-root) is (as always) a non-TXID node, so we will need to compute the hash later based on this node's children. Accordingly, we descend into the merkle root's left child and look at the next flag for instructions.
 
-![Parsing A MerkleBlock](https://raw.githubusercontent.com/dashpay/docs-core/main/img/dev/gifs/en-merkleblock-parsing/en-merkleblock-parsing-003.svg)
+![Parsing A MerkleBlock](../../img/dev/gifs/en-merkleblock-parsing/en-merkleblock-parsing-003.svg)
 
 The next flag in the example is a 0 and this is also a non-TXID node, so we apply the first hash from the [`merkleblock` message](../reference/p2p-network-data-messages.md#merkleblock) to this node. We also don't process any child nodes---according to the peer which created the [`merkleblock` message](../reference/p2p-network-data-messages.md#merkleblock), none of those nodes will lead to [TXIDs](../resources/glossary.md#transaction-identifiers) of transactions that match our filter, so we don't need them. We go back up to the merkle root and then descend into its right child and look at the next (third) flag for instructions.
 
-![Parsing A MerkleBlock](https://raw.githubusercontent.com/dashpay/docs-core/main/img/dev/gifs/en-merkleblock-parsing/en-merkleblock-parsing-004.svg)
+![Parsing A MerkleBlock](../../img/dev/gifs/en-merkleblock-parsing/en-merkleblock-parsing-004.svg)
 
 The third flag in the example is another 1 on another non-TXID node, so we descend into its left child.
 
-![Parsing A MerkleBlock](https://raw.githubusercontent.com/dashpay/docs-core/main/img/dev/gifs/en-merkleblock-parsing/en-merkleblock-parsing-005.svg)
+![Parsing A MerkleBlock](../../img/dev/gifs/en-merkleblock-parsing/en-merkleblock-parsing-005.svg)
 
 The fourth flag is also a 1 on another non-TXID node, so we descend again---we will always continue descending until we reach a TXID node or a non-TXID node with a 0 flag (or we finish filling out the tree).
 
-![Parsing A MerkleBlock](https://raw.githubusercontent.com/dashpay/docs-core/main/img/dev/gifs/en-merkleblock-parsing/en-merkleblock-parsing-006.svg)
+![Parsing A MerkleBlock](../../img/dev/gifs/en-merkleblock-parsing/en-merkleblock-parsing-006.svg)
 
 Finally, on the fifth flag in the example (a 1), we reach a TXID node. The 1 flag indicates this TXID's transaction matches our filter and that we should take the next (second) hash and use it as this node's TXID.
 
-![Parsing A MerkleBlock](https://raw.githubusercontent.com/dashpay/docs-core/main/img/dev/gifs/en-merkleblock-parsing/en-merkleblock-parsing-007.svg)
+![Parsing A MerkleBlock](../../img/dev/gifs/en-merkleblock-parsing/en-merkleblock-parsing-007.svg)
 
 The sixth flag also applies to a TXID, but it's a 0 flag, so this TXID's transaction doesn't match our filter; still, we take the next (third) hash and use it as this node's TXID.
 
-![Parsing A MerkleBlock](https://raw.githubusercontent.com/dashpay/docs-core/main/img/dev/gifs/en-merkleblock-parsing/en-merkleblock-parsing-008.svg)
+![Parsing A MerkleBlock](../../img/dev/gifs/en-merkleblock-parsing/en-merkleblock-parsing-008.svg)
 
 We now have enough information to compute the hash for the fourth node we encountered---it's the hash of the concatenated hashes of the two TXIDs we filled out.
 
-![Parsing A MerkleBlock](https://raw.githubusercontent.com/dashpay/docs-core/main/img/dev/gifs/en-merkleblock-parsing/en-merkleblock-parsing-009.svg)
+![Parsing A MerkleBlock](../../img/dev/gifs/en-merkleblock-parsing/en-merkleblock-parsing-009.svg)
 
 Moving to the right child of the third node we encountered, we fill it out using the seventh flag and final hash---and discover there are no more child nodes to process.
 
-![Parsing A MerkleBlock](https://raw.githubusercontent.com/dashpay/docs-core/main/img/dev/gifs/en-merkleblock-parsing/en-merkleblock-parsing-011.svg)
+![Parsing A MerkleBlock](../../img/dev/gifs/en-merkleblock-parsing/en-merkleblock-parsing-011.svg)
 
 We hash as appropriate to fill out the tree.  Note that the eighth flag is not used---this is acceptable as it was required to pad out a flag byte.
 

--- a/docs/examples/transaction-tutorial-offline-signing.md
+++ b/docs/examples/transaction-tutorial-offline-signing.md
@@ -150,7 +150,7 @@ a9eea0ca9368d1c99c097279b8081f88ac00000000
 
 Attempt to sign the [raw transaction](../resources/glossary.md#raw-transaction) without any special arguments, the way we successfully signed the the raw transaction in the [Simple Raw Transaction subsection](../examples/transaction-tutorial-simple-raw-transaction.md). If you've read the [Transaction section](../guide/transactions.md) of the guide, you may know why the call fails and leaves the raw transaction hex unchanged.
 
-![Old Transaction Data Required To Be Signed](https://raw.githubusercontent.com/dashpay/docs-core/main/img/dev/en-signing-output-to-spend.svg)
+![Old Transaction Data Required To Be Signed](../../img/dev/en-signing-output-to-spend.svg)
 
 As illustrated above, the data that gets signed includes the [TXID](../resources/glossary.md#transaction-identifiers) and vout from the previous transaction.  That information is included in the `createrawtransaction` raw transaction.  But the data that gets signed also includes the [pubkey script](../resources/glossary.md#pubkey-script) from the previous transaction, even though it doesn't appear in either the unsigned or signed transaction.
 

--- a/docs/guide/block-chain-block-chain-overview.md
+++ b/docs/guide/block-chain-block-chain-overview.md
@@ -1,6 +1,6 @@
 # Blockchain Overview
 
-![Block Chain Overview](https://raw.githubusercontent.com/dashpay/docs-core/main/img/dev/en-blockchain-overview.svg)
+![Block Chain Overview](../../img/dev/en-blockchain-overview.svg)
 
 The illustration above shows a simplified version of a [block chain](../resources/glossary.md#block-chain). A [block](../resources/glossary.md#block) of one or more new transactions is collected into the [transaction](../resources/glossary.md#transaction) data part of a block. Copies of each transaction are hashed, and the hashes are then paired, hashed, paired again, and hashed again until a single hash remains, the [merkle root](../resources/glossary.md#merkle-root) of a [merkle tree](../resources/glossary.md#merkle-tree).
 
@@ -8,7 +8,7 @@ The merkle root is stored in the [block header](../resources/glossary.md#block-h
 
 Transactions are also chained together. Dash [wallet](../resources/glossary.md#wallet) software gives the impression that [duffs](../resources/glossary.md#duffs) are sent from and to wallets, but Dash value really moves from transaction to transaction. Each transaction spends the duffs previously received in one or more earlier transactions, so the input of one transaction is the output of a previous transaction.
 
-![Transaction Propagation](https://raw.githubusercontent.com/dashpay/docs-core/main/img/dev/en-transaction-propagation.svg)
+![Transaction Propagation](../../img/dev/en-transaction-propagation.svg)
 
 A single transaction can create multiple [outputs](../resources/glossary.md#output), as would be the case when sending to multiple [addresses](../resources/glossary.md#address), but each output of a particular transaction can only be used as an [input](../resources/glossary.md#input) once in the blockchain. Any subsequent reference is a forbidden double spend---an attempt to spend the same duffs twice.
 

--- a/docs/guide/block-chain-block-height-and-forking.md
+++ b/docs/guide/block-chain-block-height-and-forking.md
@@ -2,7 +2,7 @@
 
 Any Dash [miner](../resources/glossary.md#miner) who successfully hashes a [block header](../resources/glossary.md#block-header) to a value below the [target threshold](../resources/glossary.md#target) can add the entire [block](../resources/glossary.md#block) to the [block chain](../resources/glossary.md#block-chain) (assuming the block is otherwise valid). These blocks are commonly addressed by their [block height](../resources/glossary.md#block-height)---the number of blocks between them and the first Dash block (block 0, most commonly known as the [genesis block](../resources/glossary.md#genesis-block)).
 
-![Common And Uncommon Block Chain Forks](https://raw.githubusercontent.com/dashpay/docs-core/main/img/dev/en-blockchain-fork.svg)
+![Common And Uncommon Block Chain Forks](../../img/dev/en-blockchain-fork.svg)
 
 Multiple blocks can all have the same block height, as is common when two or more miners each produce a block at roughly the same time. This creates an apparent [fork](../resources/glossary.md#fork) in the block chain, as shown in the illustration above.
 

--- a/docs/guide/block-chain-consensus-rule-changes.md
+++ b/docs/guide/block-chain-consensus-rule-changes.md
@@ -8,11 +8,11 @@ To maintain [consensus](../resources/glossary.md#consensus), all full [nodes](..
 
 In the first case, rejection by non-upgraded nodes, mining software which gets [block chain](../resources/glossary.md#block-chain) data from those non-upgraded nodes refuses to build on the same chain as mining software getting data from upgraded nodes. This creates permanently divergent chains---one for non-upgraded nodes and one for upgraded nodes---called a [hard fork](../resources/glossary.md#hard-fork).
 
-![Hard Fork](https://raw.githubusercontent.com/dashpay/docs-core/main/img/dev/en-hard-fork.svg)
+![Hard Fork](../../img/dev/en-hard-fork.svg)
 
 In the second case, rejection by upgraded nodes, it's possible to keep the block chain from permanently diverging if upgraded nodes control a majority of the hash rate. That's because, in this case, non-upgraded nodes will accept as valid all the same blocks as upgraded nodes, so the upgraded nodes can build a stronger chain that the non-upgraded nodes will accept as the best valid block chain. This is called a [soft fork](../resources/glossary.md#soft-fork).
 
-![Soft Fork](https://raw.githubusercontent.com/dashpay/docs-core/main/img/dev/en-soft-fork.svg)
+![Soft Fork](../../img/dev/en-soft-fork.svg)
 
 Although a fork is an actual divergence in block chains, changes to the consensus rules are often described by their potential to create either a hard or soft fork. For example, "increasing the block size requires a hard fork." In this example, an actual block chain fork is not required---but it is a possible outcome.
 

--- a/docs/guide/contracts-micropayment-channel.md
+++ b/docs/guide/contracts-micropayment-channel.md
@@ -6,7 +6,7 @@ Bob asks Alice for her [public key](../resources/glossary.md#public-key) and the
 
 The second transaction spends all of the first transaction's millidash (minus a transaction fee) back to Bob after a 24 hour delay enforced by locktime. This is the refund transaction. Bob can't sign the refund transaction by himself, so he gives it to Alice to sign, as shown in the illustration below.
 
-![Micropayment Channel Example](https://raw.githubusercontent.com/dashpay/docs-core/main/img/dev/en-micropayment-channel.svg)
+![Micropayment Channel Example](../../img/dev/en-micropayment-channel.svg)
 
 Alice checks that the refund transaction's locktime is 24 hours in the future, signs it, and gives a copy of it back to Bob. She then asks Bob for the bond transaction and checks that the refund transaction spends the output of the bond transaction. She can now broadcast the bond transaction to the network to ensure Bob has to wait for the time lock to expire before further spending his millidash. Bob hasn't actually spent anything so far, except possibly a small [transaction fee](../resources/glossary.md#transaction-fee), and he'll be able to broadcast the refund transaction in 24 hours for a full refund.
 

--- a/docs/guide/dash-features-masternode-sync.md
+++ b/docs/guide/dash-features-masternode-sync.md
@@ -13,7 +13,7 @@ The deterministic masternode lists introduced by [DIP3](https://github.com/dashp
 
 This diagram shows the order in which P2P messages are sent to perform masternode synchronization initially after startup.
 
-![Masternode Sync (Initial)](https://raw.githubusercontent.com/dashpay/docs-core/main/img/dev/en-masternode-sync-initial-dip3.svg)
+![Masternode Sync (Initial)](../../img/dev/en-masternode-sync-initial-dip3.svg)
 
 The following table details the data flow of P2P messages exchanged during initial masternode synchronization after the activation of [DIP3](https://github.com/dashpay/dips/blob/master/dip-0003.md) and [Spork](../resources/glossary.md#spork) 15.
 
@@ -43,7 +43,7 @@ There are several status values used to track masternode synchronization. They a
 
 Once a masternode completes an initial full sync, continuing synchronization is maintained by the exchange of P2P messages with other [nodes](../resources/glossary.md#node). This diagram shows an overview of the messages exchanged to keep governance objects synchronized between masternodes.
 
-![Masternode Sync (Ongoing)](https://raw.githubusercontent.com/dashpay/docs-core/main/img/dev/en-masternode-sync-ongoing.svg)
+![Masternode Sync (Ongoing)](../../img/dev/en-masternode-sync-ongoing.svg)
 
 **Governance**
 

--- a/docs/guide/mining-pool-mining.md
+++ b/docs/guide/mining-pool-mining.md
@@ -2,7 +2,7 @@
 
 Pool miners follow a similar workflow, illustrated below, which allows mining pool operators to pay miners based on their share of the work done. The mining pool gets new [transactions](../resources/glossary.md#transaction) from the network using `dashd`. Using one of the methods discussed later, each miner's mining software connects to the pool and requests the information it needs to construct block headers.
 
-![Pooled Bitcoin Mining](https://raw.githubusercontent.com/dashpay/docs-core/main/img/dev/en-pooled-mining-overview.svg)
+![Pooled Bitcoin Mining](../../img/dev/en-pooled-mining-overview.svg)
 
 In pooled mining, the mining pool sets the [target threshold](../resources/glossary.md#target) a few orders of magnitude higher (less difficult) than the network difficulty. This causes the mining hardware to return many block headers which don't hash to a value eligible for inclusion on the [block chain](../resources/glossary.md#block-chain) but which do hash below the pool's target, proving (on average) that the miner checked a percentage of the possible hash values.
 

--- a/docs/guide/mining-solo-mining.md
+++ b/docs/guide/mining-solo-mining.md
@@ -2,7 +2,7 @@
 
 As illustrated below, solo miners typically use `dashd` to get new [transactions](../resources/glossary.md#transaction) from the [network](../resources/glossary.md#network). Their mining software periodically polls `dashd` for new transactions using the [`getblocktemplate` RPC](../api/remote-procedure-calls-mining.md#getblocktemplate), which provides the list of new transactions plus the [public key](../resources/glossary.md#public-key) to which the [coinbase transaction](../resources/glossary.md#coinbase-transaction) should be sent.
 
-![Solo Bitcoin Mining](https://raw.githubusercontent.com/dashpay/docs-core/main/img/dev/en-solo-mining-overview.svg)
+![Solo Bitcoin Mining](../../img/dev/en-solo-mining-overview.svg)
 
 The mining software constructs a block using the template (described below) and creates a [block header](../resources/glossary.md#block-header). It then sends the 80-byte block header to its mining hardware (an ASIC) along with a [target threshold](../resources/glossary.md#target) (difficulty setting). The mining hardware iterates through every possible value for the block header nonce and generates the corresponding hash.
 

--- a/docs/guide/operating-modes-full-node.md
+++ b/docs/guide/operating-modes-full-node.md
@@ -4,4 +4,4 @@ The first and most secure model is the one followed by Dash Core, also known as 
 
 For a client to be fooled, an adversary would need to give a complete alternative block chain history that is of greater difficulty than the current “true” chain, which is computationally expensive (if not impossible) due to the fact that the chain with the most cumulative [proof of work](../resources/glossary.md#proof-of-work) is by definition the "true" chain. Due to the computational difficulty required to generate a new block at the tip of the chain, the ability to fool a full node becomes very expensive after 6 [confirmations](../resources/glossary.md#confirmations). This form of verification is highly resistant to Sybil attacks---only a single honest [network](../resources/glossary.md#network) [peer](../resources/glossary.md#peer) is required in order to receive and verify the complete state of the "true" block chain.
 
-![Block Height Compared To Block Depth](https://raw.githubusercontent.com/dashpay/docs-core/main/img/dev/en-block-height-vs-depth.svg)
+![Block Height Compared To Block Depth](../../img/dev/en-block-height-vs-depth.svg)

--- a/docs/guide/p2p-network-block-broadcasting.md
+++ b/docs/guide/p2p-network-block-broadcasting.md
@@ -32,7 +32,7 @@ Full nodes validate the received block and then advertise it to their peers usin
 
 Blocks-first nodes may download [orphan blocks](../resources/glossary.md#orphan-block)---blocks whose previous [block header](../resources/glossary.md#block-header) hash field refers to a block header this node hasn't seen yet. In other words, orphan blocks have no known parent (unlike [stale blocks](../resources/glossary.md#stale-block), which have known parents but which aren't part of the best [block chain](../resources/glossary.md#block-chain)).
 
-![Difference Between Orphan And Stale Blocks](https://raw.githubusercontent.com/dashpay/docs-core/main/img/dev/en-orphan-stale-definition.svg)
+![Difference Between Orphan And Stale Blocks](../../img/dev/en-orphan-stale-definition.svg)
 
 When a [blocks-first](../resources/glossary.md#blocks-first-sync) node downloads an orphan block, it will not validate it. Instead, it will send a [`getblocks` message](../reference/p2p-network-data-messages.md#getblocks) to the node which sent the orphan block; the broadcasting node will respond with an [`inv` message](../reference/p2p-network-data-messages.md#inv) containing [inventories](../resources/glossary.md#inventory) of any blocks the downloading node is missing (up to 500); the downloading node will request those blocks with a [`getdata` message](../reference/p2p-network-data-messages.md#getdata); and the broadcasting node will send those blocks with a [`block` message](../reference/p2p-network-data-messages.md#block). The downloading node will validate those blocks, and once the parent of the former orphan block has been validated, it will validate the former orphan block.
 

--- a/docs/guide/p2p-network-initial-block-download.md
+++ b/docs/guide/p2p-network-initial-block-download.md
@@ -10,17 +10,17 @@ Dash Core uses the IBD method any time the last block on its local best block ch
 
 Dash Core (up until version 0.12.0.x) uses a simple initial block download (IBD) method we'll call *blocks-first*. The goal is to download the blocks from the best block chain in sequence.
 
-![Overview Of Blocks-First Method](https://raw.githubusercontent.com/dashpay/docs-core/main/img/dev/en-blocks-first-flowchart.svg)
+![Overview Of Blocks-First Method](../../img/dev/en-blocks-first-flowchart.svg)
 
 The first time a node is started, it only has a single block in its local best block chain---the hardcoded genesis block (block 0).  This node chooses a remote [peer](../resources/glossary.md#peer), called the sync node, and sends it the [`getblocks` message](../reference/p2p-network-data-messages.md#getblocks) illustrated below.
 
-![First GetBlocks Message Sent During IBD](https://raw.githubusercontent.com/dashpay/docs-core/main/img/dev/en-ibd-getblocks.svg)
+![First GetBlocks Message Sent During IBD](../../img/dev/en-ibd-getblocks.svg)
 
 In the header hashes field of the [`getblocks` message](../reference/p2p-network-data-messages.md#getblocks), this new node sends the header hash of the only block it has, the genesis block (`b67a...0000` in [internal byte order](../resources/glossary.md#internal-byte-order)).  It also sets the stop hash field to all zeroes to request a maximum-size response.
 
 Upon receipt of the [`getblocks` message](../reference/p2p-network-data-messages.md#getblocks), the sync node takes the first (and only) header hash and searches its local best block chain for a block with that header hash. It finds that block 0 matches, so it replies with 500 block [inventories](../resources/glossary.md#inventory) (the maximum response to a [`getblocks` message](../reference/p2p-network-data-messages.md#getblocks)) starting from block 1. It sends these inventories in the [`inv` message](../reference/p2p-network-data-messages.md#inv) illustrated below.
 
-![First Inv Message Sent During IBD](https://raw.githubusercontent.com/dashpay/docs-core/main/img/dev/en-ibd-inv.svg)
+![First Inv Message Sent During IBD](../../img/dev/en-ibd-inv.svg)
 
 Inventories are unique identifiers for information on the [network](../resources/glossary.md#network). Each inventory contains a type field and the unique identifier for an instance of the object. For blocks, the unique identifier is a hash of the block's header.
 
@@ -28,17 +28,17 @@ The block inventories appear in the [`inv` message](../reference/p2p-network-dat
 
 The IBD node uses the received inventories to request 128 blocks from the sync node in the [`getdata` message](../reference/p2p-network-data-messages.md#getdata) illustrated below.
 
-![First GetData Message Sent During IBD](https://raw.githubusercontent.com/dashpay/docs-core/main/img/dev/en-ibd-getdata.svg)
+![First GetData Message Sent During IBD](../../img/dev/en-ibd-getdata.svg)
 
 It's important to [blocks-first](../resources/glossary.md#blocks-first-sync) nodes that the blocks be requested and sent in order because each block header references the header hash of the preceding block. That means the IBD node can't fully validate a block until its parent block has been received. Blocks that can't be validated because their parents haven't been received are called [orphan blocks](../resources/glossary.md#orphan-block); a subsection below describes them in more detail.
 
 Upon receipt of the [`getdata` message](../reference/p2p-network-data-messages.md#getdata), the sync node replies with each of the blocks requested. Each block is put into [serialized block](../resources/glossary.md#serialized-block) format and sent in a separate [`block` message](../reference/p2p-network-data-messages.md#block). The first [`block` message](../reference/p2p-network-data-messages.md#block) sent (for block 1) is illustrated below.
 
-![First Block Message Sent During IBD](https://raw.githubusercontent.com/dashpay/docs-core/main/img/dev/en-ibd-block.svg)
+![First Block Message Sent During IBD](../../img/dev/en-ibd-block.svg)
 
 The IBD node downloads each block, validates it, and then requests the next block it hasn't requested yet, maintaining a queue of up to 128 blocks to download. When it has requested every block for which it has an inventory, it sends another [`getblocks` message](../reference/p2p-network-data-messages.md#getblocks) to the sync node requesting the inventories of up to 500 more blocks.  This second [`getblocks` message](../reference/p2p-network-data-messages.md#getblocks) contains multiple header hashes as illustrated below:
 
-![Second GetBlocks Message Sent During IBD](https://raw.githubusercontent.com/dashpay/docs-core/main/img/dev/en-ibd-getblocks2.svg)
+![Second GetBlocks Message Sent During IBD](../../img/dev/en-ibd-getblocks2.svg)
 
 Upon receipt of the second [`getblocks` message](../reference/p2p-network-data-messages.md#getblocks), the sync node searches its local best block chain for a block that matches one of the header hashes in the message, trying each hash in the order they were received. If it finds a matching hash, it replies with 500 block inventories starting with the next block from that point. But if there is no matching hash (besides the stopping hash), it assumes the only block the two nodes have in common is block 0 and so it sends an `inv` starting with block 1 (the same [`inv` message](../reference/p2p-network-data-messages.md#inv) seen several illustrations above).
 
@@ -71,17 +71,17 @@ All of these problems are addressed in part or in full by the headers-first IBD 
 
 Dash Core 0.12.0+ uses an [initial block download](../resources/glossary.md#initial-block-download) (IBD) method called *[headers-first](../resources/glossary.md#headers-first-sync)*. The goal is to download the [headers](../resources/glossary.md#header) for the best [header chain](../resources/glossary.md#header-chain), partially validate them as best as possible, and then download the corresponding [blocks](../resources/glossary.md#block) in parallel.  This solves several problems with the older [blocks-first](../resources/glossary.md#blocks-first-sync) IBD method.
 
-![Overview Of Headers-First Method](https://raw.githubusercontent.com/dashpay/docs-core/main/img/dev/en-headers-first-flowchart.svg)
+![Overview Of Headers-First Method](../../img/dev/en-headers-first-flowchart.svg)
 
 The first time a node is started, it only has a single block in its local best [block chain](../resources/glossary.md#block-chain)---the hardcoded [genesis block](../resources/glossary.md#genesis-block) (block 0).  The node chooses a remote [peer](../resources/glossary.md#peer), which we'll call the sync node, and sends it the [`getheaders` message](../reference/p2p-network-data-messages.md#getheaders) illustrated below.
 
-![First getheaders message](https://raw.githubusercontent.com/dashpay/docs-core/main/img/dev/en-ibd-getheaders.svg)
+![First getheaders message](../../img/dev/en-ibd-getheaders.svg)
 
 In the header hashes field of the [`getheaders` message](../reference/p2p-network-data-messages.md#getheaders), the new node sends the header hash of the only block it has, the genesis block (`b67a...0000` in internal byte order).  It also sets the stop hash field to all zeroes to request a maximum-size response.
 
 Upon receipt of the [`getheaders` message](../reference/p2p-network-data-messages.md#getheaders), the sync node takes the first (and only) header hash and searches its local best block chain for a block with that header hash. It finds that block 0 matches, so it replies with 2,000 header (the maximum response) starting from block 1. It sends these header hashes in the [`headers` message](../reference/p2p-network-data-messages.md#headers) illustrated below.
 
-![First headers message](https://raw.githubusercontent.com/dashpay/docs-core/main/img/dev/en-ibd-headers.svg)
+![First headers message](../../img/dev/en-ibd-headers.svg)
 
 The [IBD](../resources/glossary.md#initial-block-download) [node](../resources/glossary.md#node) can partially validate these block headers by ensuring that all fields follow [consensus rules](../resources/glossary.md#consensus-rules) and that the hash of the header is below the [target threshold](../resources/glossary.md#target) according to the nBits field.  (Full validation still requires all transactions from the corresponding block.)
 
@@ -95,7 +95,7 @@ After the IBD node has partially validated the block headers, it can do two thin
 
     To spread the load between multiple peers, Dash Core will only request up to 16 blocks at a time from a single peer. Combined with its maximum of 8 outbound connections, this means Dash Core using headers-first will request a maximum of 128 blocks simultaneously during IBD (the same maximum number that blocks-first Dash Core requested from its sync node).
 
-![Simulated Headers-First Download Window](https://raw.githubusercontent.com/dashpay/docs-core/main/img/dev/en-headers-first-moving-window.svg)
+![Simulated Headers-First Download Window](../../img/dev/en-headers-first-moving-window.svg)
 
 Dash Core's headers-first mode uses a 1,024-block moving download window to maximize download speed. The lowest-height block in the window is the next block to be validated; if the block hasn't arrived by the time Dash Core is ready to validate it, Dash Core will wait a minimum of two more seconds for the stalling node to send the block. If the block still hasn't arrived, Dash Core will disconnect from the stalling node and attempt to connect to another node. For example, in the illustration above, Node A will be disconnected if it doesn't send block 3 within at least two seconds.
 

--- a/docs/guide/transactions-p2pkh-script-validation.md
+++ b/docs/guide/transactions-p2pkh-script-validation.md
@@ -16,7 +16,7 @@ The script language is a [Forth-like](https://en.wikipedia.org/wiki/Forth_%28pro
 
 To test whether the transaction is valid, signature script and pubkey script operations are executed one item at a time, starting with Bob's signature script and continuing to the end of Alice's pubkey script. The figure below shows the evaluation of a standard P2PKH pubkey script; below the figure is a description of the process.
 
-![P2PKH Stack Evaluation](https://raw.githubusercontent.com/dashpay/docs-core/main/img/dev/en-p2pkh-stack.svg)
+![P2PKH Stack Evaluation](../../img/dev/en-p2pkh-stack.svg)
 
 * The [signature](../resources/glossary.md#signature) (from Bob's signature script) is added (pushed) to an empty stack. Because it's just data, nothing is done except adding it to the stack. The [public key](../resources/glossary.md#public-key) (also from the signature script) is pushed on top of the signature.
 

--- a/docs/guide/transactions-p2sh-scripts.md
+++ b/docs/guide/transactions-p2sh-scripts.md
@@ -6,10 +6,10 @@ To solve these problems, pay-to-script-hash ([P2SH](../resources/glossary.md#pay
 
 The basic P2SH workflow, illustrated below, looks almost identical to the [P2PKH](../resources/glossary.md#pay-to-pubkey-hash) workflow. Bob creates a redeem script with whatever script he wants, hashes the redeem script, and provides the [redeem script](../resources/glossary.md#redeem-script) hash to Alice. Alice creates a P2SH-style [output](../resources/glossary.md#output) containing Bob's redeem script hash.
 
-![Creating A P2SH Redeem Script And Hash](https://raw.githubusercontent.com/dashpay/docs-core/main/img/dev/en-creating-p2sh-output.svg)
+![Creating A P2SH Redeem Script And Hash](../../img/dev/en-creating-p2sh-output.svg)
 
 When Bob wants to spend the [output](../resources/glossary.md#output), he provides his [signature](../resources/glossary.md#signature) along with the full (serialized) redeem script in the [signature script](../resources/glossary.md#signature-script). The peer-to-peer [network](../resources/glossary.md#network) ensures the full redeem script hashes to the same value as the script hash Alice put in her output; it then processes the redeem script exactly as it would if it were the primary pubkey script, letting Bob spend the output if the redeem script does not return false.
 
-![Unlocking A P2SH Output For Spending](https://raw.githubusercontent.com/dashpay/docs-core/main/img/dev/en-unlocking-p2sh-output.svg)
+![Unlocking A P2SH Output For Spending](../../img/dev/en-unlocking-p2sh-output.svg)
 
 The hash of the redeem script has the same properties as a pubkey hash---so it can be transformed into the standard Dash address format with only one small change to differentiate it from a standard address. This makes collecting a P2SH-style address as simple as collecting a P2PKH-style address. The hash also obfuscates any public keys in the redeem script, so P2SH scripts are as secure as P2PKH pubkey hashes.

--- a/docs/guide/transactions.md
+++ b/docs/guide/transactions.md
@@ -4,13 +4,13 @@ Transactions let users spend [duffs](../resources/glossary.md#duffs). Each [tran
 
 To keep things simple, this section pretends coinbase transactions do not exist. Coinbase transactions can only be created by Dash miners and they're an exception to many of the rules listed below. Instead of pointing out the coinbase exception to each rule, we invite you to read about coinbase transactions in the [block chain](../resources/glossary.md#block-chain) [section](../guide/block-chain.md) of this guide.
 
-![The Parts Of A Transaction](https://raw.githubusercontent.com/dashpay/docs-core/main/img/dev/en-tx-overview.svg)
+![The Parts Of A Transaction](../../img/dev/en-tx-overview.svg)
 
 The figure above shows the main parts of a Dash transaction. Each transaction has at least one [input](../resources/glossary.md#input) and one [output](../resources/glossary.md#output). Each [input](../resources/glossary.md#input) spends the duffs paid to a previous output. Each [output](../resources/glossary.md#output) then waits as an Unspent Transaction Output (UTXO) until a later input spends it. When your Dash wallet tells you that you have a 10,000 duff balance, it really means that you have 10,000 duffs waiting in one or more UTXOs.
 
 Each transaction is prefixed by a four-byte [transaction version number](../resources/glossary.md#transaction-version-number) which tells Dash [peers](../resources/glossary.md#peer) and miners which set of rules to use to validate it.  This lets developers create new rules for future transactions without invalidating previous transactions.
 
-![Spending An Output](https://raw.githubusercontent.com/dashpay/docs-core/main/img/dev/en-tx-overview-spending.svg)
+![Spending An Output](../../img/dev/en-tx-overview-spending.svg)
 
 An output has an implied [index](../resources/glossary.md#index) number based on its location in the transaction---the index of the first output is zero. The output also has an amount in duffs which it pays to a conditional [pubkey script](../resources/glossary.md#pubkey-script). Anyone who can satisfy the conditions of that pubkey script can spend up to the amount of duffs paid to it.
 
@@ -18,7 +18,7 @@ An input uses a transaction identifier ([TXID](../resources/glossary.md#transact
 
 The figures below help illustrate how these features are used by showing the workflow Alice uses to send Bob a transaction and which Bob later uses to spend that transaction. Both Alice and Bob will use the most common form of the standard Pay-To-Public-Key-Hash (P2PKH) transaction type. [P2PKH](../resources/glossary.md#pay-to-pubkey-hash) lets Alice spend duffs to a typical Dash [address](../resources/glossary.md#address), and then lets Bob further spend those duffs using a simple cryptographic key pair.
 
-![Creating A P2PKH Public Key Hash To Receive Payment](https://raw.githubusercontent.com/dashpay/docs-core/main/img/dev/en-creating-p2pkh-output.svg)
+![Creating A P2PKH Public Key Hash To Receive Payment](../../img/dev/en-creating-p2pkh-output.svg)
 
 Bob must first generate a private/public [key pair](../resources/glossary.md#key-pair) before Alice can create the first transaction. Dash uses the Elliptic Curve Digital Signature Algorithm (ECDSA) with the secp256k1 curve; secp256k1 [private keys](../resources/glossary.md#private-key) are 256 bits of random data. A copy of that data is deterministically transformed into an secp256k1 [public key](../resources/glossary.md#public-key). Because the transformation can be reliably repeated later, the public key does not need to be stored.
 
@@ -35,7 +35,7 @@ When, some time later, Bob decides to spend the UTXO, he must create an input wh
 
 Pubkey scripts and signature scripts combine secp256k1 pubkeys and [signatures](../resources/glossary.md#signature) with conditional logic, creating a programmable authorization mechanism.
 
-![Unlocking A P2PKH Output For Spending](https://raw.githubusercontent.com/dashpay/docs-core/main/img/dev/en-unlocking-p2pkh-output.svg)
+![Unlocking A P2PKH Output For Spending](../../img/dev/en-unlocking-p2pkh-output.svg)
 
 For a P2PKH-style output, Bob's signature script will contain the following two pieces of data:
 
@@ -45,7 +45,7 @@ For a P2PKH-style output, Bob's signature script will contain the following two 
 
 Bob's secp256k1 signature doesn't just prove Bob controls his private key; it also makes the non-signature-script parts of his transaction tamper-proof so Bob can safely broadcast them over the peer-to-peer network.
 
-![Some Things Signed When Spending An Output](https://raw.githubusercontent.com/dashpay/docs-core/main/img/dev/en-signing-output-to-spend.svg)
+![Some Things Signed When Spending An Output](../../img/dev/en-signing-output-to-spend.svg)
 
 As illustrated in the figure above, the data Bob signs includes the txid and output index of the previous transaction, the previous output's pubkey script, the pubkey script Bob creates which will let the next recipient spend this transaction's output, and the amount of duffs to spend to the next recipient. In essence, the entire transaction is signed except for any signature scripts, which hold the full public keys and secp256k1 signatures.
 

--- a/docs/guide/wallets-wallet-files.md
+++ b/docs/guide/wallets-wallet-files.md
@@ -50,7 +50,7 @@ Many implementations disallow the character '1' in the mini private key due to i
 
 Dash ECDSA public keys represent a point on a particular Elliptic Curve (EC) defined in secp256k1. In their traditional uncompressed form, public keys contain an identification byte, a 32-byte X coordinate, and a 32-byte Y coordinate. The extremely simplified illustration below shows such a point on the elliptic curve used by Dash, y<sup>2</sup>&nbsp;=&nbsp;x<sup>3</sup>&nbsp;+&nbsp;7, over a field of contiguous numbers.
 
-![Point On ECDSA Curve](https://raw.githubusercontent.com/dashpay/docs-core/main/img/dev/en-ecdsa-compressed-public-key.svg)
+![Point On ECDSA Curve](../../img/dev/en-ecdsa-compressed-public-key.svg)
 
 (Secp256k1 actually modulos coordinates by a large prime, which produces a field of non-contiguous integers and a significantly less clear plot, although the principles are the same.)
 
@@ -90,7 +90,7 @@ Whether creating child public keys or further-descended public keys, a predictab
 
 The HD protocol uses a single [root seed](../resources/glossary.md#root-seed) to create a hierarchy of child, grandchild, and other descended keys with unlinkable deterministically-generated integer values. Each child key also gets a deterministically-generated seed from its parent, called a [chain code](../resources/glossary.md#chain-code), so the compromising of one chain code doesn't necessarily compromise the integer sequence for the whole hierarchy, allowing the [master chain code](../resources/glossary.md#master-chain-code-and-private-key) to continue being useful even if, for example, a web-based public key distribution program gets hacked.
 
-![Overview Of Hierarchical Deterministic Key Derivation](https://raw.githubusercontent.com/dashpay/docs-core/main/img/dev/en-hd-overview.svg)
+![Overview Of Hierarchical Deterministic Key Derivation](../../img/dev/en-hd-overview.svg)
 
 As illustrated above, HD key derivation takes four inputs:
 
@@ -112,7 +112,7 @@ Specifying different index numbers will create different unlinkable child keys f
 
 Because creating child keys requires both a key and a chain code, the key and chain code together are called the [extended key](../resources/glossary.md#extended-key). An [extended private key](../resources/glossary.md#extended-private-key) and its corresponding [extended public key](../resources/glossary.md#extended-public-key) have the same chain code. The (top-level parent) [master private key](../resources/glossary.md#master-private-key) and master chain code are derived from random data, as illustrated below.
 
-![Creating A Root Extended Key Pair](https://raw.githubusercontent.com/dashpay/docs-core/main/img/dev/en-hd-root-keys.svg)
+![Creating A Root Extended Key Pair](../../img/dev/en-hd-root-keys.svg)
 
 A [root seed](../resources/glossary.md#root-seed) is created from either 128 bits, 256 bits, or 512 bits of random data. This root seed of as little as 128 bits is the the only data the user needs to backup in order to derive every key created by a particular wallet program using particular settings.
 
@@ -126,7 +126,7 @@ The root seed is hashed to create 512 bits of seemingly-random data, from which 
 
 Hardened extended keys fix a potential problem with normal extended keys. If an attacker gets a normal parent chain code and parent public key, he can brute-force all chain codes deriving from it. If the attacker also obtains a child, grandchild, or further-descended private key, he can use the chain code to generate all of the extended private keys descending from that private key, as shown in the grandchild and great-grandchild generations of the illustration below.
 
-![Cross-Generational Key Compromise](https://raw.githubusercontent.com/dashpay/docs-core/main/img/dev/en-hd-cross-generational-key-compromise.svg)
+![Cross-Generational Key Compromise](../../img/dev/en-hd-cross-generational-key-compromise.svg)
 
 Perhaps worse, the attacker can reverse the normal [child private key](../resources/glossary.md#child-private-key) derivation formula and subtract a [parent chain code](../resources/glossary.md#parent-chain-code) from a child private key to recover the [parent private key](../resources/glossary.md#parent-private-key), as shown in the child and parent generations of the illustration above.  This means an attacker who acquires an [extended public key](../resources/glossary.md#extended-public-key) and any private key descended from it can recover that public key's private key and all keys descended from it.
 
@@ -136,7 +136,7 @@ This can be fixed, with some tradeoffs, by replacing the the normal key derivati
 
 The normal key derivation formula, described in the section above, combines together the index number, the parent chain code, and the parent public key to create the child chain code and the integer value which is combined with the parent private key to create the child private key.
 
-![Creating Child Public Keys From An Extended Private Key](https://raw.githubusercontent.com/dashpay/docs-core/main/img/dev/en-hd-private-parent-to-private-child.svg)
+![Creating Child Public Keys From An Extended Private Key](../../img/dev/en-hd-private-parent-to-private-child.svg)
 
 The hardened formula, illustrated above, combines together the index number, the parent chain code, and the parent private key to create the data used to generate the child chain code and child private key. This formula makes it impossible to create child public keys without knowing the parent private key. In other words, parent extended public keys can't create hardened child public keys.
 
@@ -150,7 +150,7 @@ The HD protocol uses different index numbers to indicate whether a normal or har
 
 This compact description is further combined with slashes prefixed by *m* or *M* to indicate hierarchy and key type, with *m* being a private key and *M* being a public key. For example, m/0'/0/122' refers to the 123rd hardened private child (by index number) of the first normal child (by index) of the first hardened child (by index) of the master private key. The following hierarchy illustrates prime notation and hardened key firewalls.
 
-![Example HD Wallet Tree Using Prime Notation](https://raw.githubusercontent.com/dashpay/docs-core/main/img/dev/en-hd-tree.svg)
+![Example HD Wallet Tree Using Prime Notation](../../img/dev/en-hd-tree.svg)
 
 Wallets following the [BIP32](../resources/glossary.md#bip32) [HD protocol](../resources/glossary.md#bip32) only create hardened children of the master private key (*m*) to prevent a compromised child key from compromising the master key. As there are no normal children for the master keys, the master public key is not used in HD wallets. All other keys can have normal children, so the corresponding extended public keys may be used instead.
 

--- a/docs/guide/wallets-wallet-programs.md
+++ b/docs/guide/wallets-wallet-programs.md
@@ -14,7 +14,7 @@ This leaves us with three necessary, but separable, parts of a wallet system: a 
 
 The simplest wallet is a program which performs all three functions: it generates [private keys](../resources/glossary.md#private-key), derives the corresponding [public keys](../resources/glossary.md#public-key), helps distribute those public keys as necessary, monitors for outputs spent to those public keys, creates and signs transactions spending those outputs, and broadcasts the signed transactions.
 
-![Full-Service Wallets](https://raw.githubusercontent.com/dashpay/docs-core/main/img/dev/en-wallets-full-service.svg)
+![Full-Service Wallets](../../img/dev/en-wallets-full-service.svg)
 
 As of this writing, almost all popular wallets can be used as full-service wallets.
 
@@ -30,7 +30,7 @@ To increase security, private keys can be generated and stored by a separate wal
 
 Signing-only wallets programs typically use deterministic key creation (described in a [later subsection](../guide/wallets-wallet-files.md#hierarchical-deterministic-key-creation)) to create parent private and public keys which can create child private and public keys.
 
-![Signing-Only Wallets](https://raw.githubusercontent.com/dashpay/docs-core/main/img/dev/en-wallets-signing-only.svg)
+![Signing-Only Wallets](../../img/dev/en-wallets-signing-only.svg)
 
 When first run, the signing-only wallet creates a [parent private key](../resources/glossary.md#parent-private-key) and transfers the corresponding [parent public key](../resources/glossary.md#parent-public-key) to the networked wallet.
 
@@ -82,7 +82,7 @@ The primary disadvantage of hardware wallets is their hassle. Even though the ha
 
 Wallet programs which run in difficult-to-secure environments, such as webservers, can be designed to distribute public keys (including P2PKH or P2SH addresses) and nothing more.  There are two common ways to design these minimalist wallets:
 
-![Distributing-Only Wallets](https://raw.githubusercontent.com/dashpay/docs-core/main/img/dev/en-wallets-distributing-only.svg)
+![Distributing-Only Wallets](../../img/dev/en-wallets-distributing-only.svg)
 
 * Pre-populate a database with a number of public keys or addresses, and then distribute on request a pubkey script or address using one of the database entries. To [avoid key reuse](../guide/transactions-avoiding-key-reuse.md), webservers should keep track of used keys and never run out of public keys. This can be made easier by using parent public keys as suggested in the next method.
 

--- a/docs/reference/block-chain-block-headers.md
+++ b/docs/reference/block-chain-block-headers.md
@@ -59,7 +59,7 @@ If a block only has a coinbase transaction and one other transaction, the TXIDs 
 
 If a block has three or more transactions, intermediate [merkle tree](../resources/glossary.md#merkle-tree) rows are formed. The TXIDs are placed in order and paired, starting with the coinbase transaction's TXID. Each pair is concatenated together as 64 raw bytes and SHA256(SHA256()) hashed to form a second row of hashes. If there are an odd (non-even) number of TXIDs, the last TXID is concatenated with a copy of itself and hashed. If there are more than two hashes in the second row, the process is repeated to create a third row (and, if necessary, repeated further to create additional rows). Once a row is obtained with only two hashes, those hashes are concatenated and hashed to produce the merkle root.
 
-![Example Merkle Tree Construction](https://raw.githubusercontent.com/dashpay/docs-core/main/img/dev/en-merkle-tree-construction.png)
+![Example Merkle Tree Construction](../../img/dev/en-merkle-tree-construction.png)
 
 TXIDs and intermediate hashes are always in [internal byte order](../resources/glossary.md#internal-byte-order) when they're concatenated, and the resulting merkle root is also in internal byte order when it's placed in the [block header](../resources/glossary.md#block-header).
 
@@ -67,11 +67,11 @@ TXIDs and intermediate hashes are always in [internal byte order](../resources/g
 
 The [target threshold](../resources/glossary.md#target) is a 256-bit unsigned integer which a [header](../resources/glossary.md#header) hash must be equal to or below in order for that header to be a valid part of the [block chain](../resources/glossary.md#block-chain). However, the header field *[nBits](../resources/glossary.md#nbits)* provides only 32 bits of space, so the [target](../resources/glossary.md#target) number uses a less precise format called "compact" which works like a base-256 version of scientific notation:
 
-![Converting nBits Into A Target Threshold](https://raw.githubusercontent.com/dashpay/docs-core/main/img/dev/en-nbits-overview.png)
+![Converting nBits Into A Target Threshold](../../img/dev/en-nbits-overview.png)
 
 As a base-256 number, nBits can be quickly parsed as bytes the same way you might parse a decimal number in base-10 scientific notation:
 
-![Quickly Converting nBits](https://raw.githubusercontent.com/dashpay/docs-core/main/img/dev/en-nbits-quick-parse.png)
+![Quickly Converting nBits](../../img/dev/en-nbits-quick-parse.png)
 
 Although the target threshold should be an unsigned integer, the original nBits implementation inherits properties from a signed data class, allowing the target threshold to be negative if the high bit of the significand is set. This is useless---the header hash is treated as an unsigned number, so it can never be equal to or lower than a negative target threshold. Dash Core deals with this in two ways:
 

--- a/docs/reference/p2p-network-control-messages.md
+++ b/docs/reference/p2p-network-control-messages.md
@@ -2,7 +2,7 @@
 
 The following [network](../resources/glossary.md#network) messages all help control the connection between two [peers](../resources/glossary.md#peer) or allow them to advise each other about the rest of the network.
 
-![Overview Of P2P Protocol Control And Advisory Messages](https://raw.githubusercontent.com/dashpay/docs-core/main/img/dev/en-p2p-control-messages.svg)
+![Overview Of P2P Protocol Control And Advisory Messages](../../img/dev/en-p2p-control-messages.svg)
 
 Note that almost none of the control messages are authenticated in any way, meaning they can contain incorrect or intentionally harmful information.
 
@@ -237,7 +237,7 @@ The following annotated hexdump of a transaction is from the [raw transaction fo
 
 Clients will often want to track [inputs](../resources/glossary.md#input) that spend [outputs](../resources/glossary.md#output) (outpoints) relevant to their wallet, so the filterload field *nFlags* can be set to allow the filtering [node](../resources/glossary.md#node) to update the filter when a match is found. When the filtering node sees a [pubkey script](../resources/glossary.md#pubkey-script) that pays a pubkey, [address](../resources/glossary.md#address), or other data element matching the filter, the filtering node immediately updates the filter with the [outpoint](../resources/glossary.md#outpoint) corresponding to that pubkey script.
 
-![Automatically Updating Bloom Filters](https://raw.githubusercontent.com/dashpay/docs-core/main/img/dev/en-bloom-update.svg)
+![Automatically Updating Bloom Filters](../../img/dev/en-bloom-update.svg)
 
 If an input later spends that outpoint, the filter will match it, allowing the filtering node to tell the client that one of its transaction outputs has been spent.
 

--- a/docs/reference/p2p-network-data-messages.md
+++ b/docs/reference/p2p-network-data-messages.md
@@ -2,7 +2,7 @@
 
 The following network messages all request or provide data related to transactions and blocks.
 
-![Overview Of P2P Protocol Data Request And Reply Messages](https://raw.githubusercontent.com/dashpay/docs-core/main/img/dev/en-p2p-data-messages.svg)
+![Overview Of P2P Protocol Data Request And Reply Messages](../../img/dev/en-p2p-data-messages.svg)
 
 Many of the data messages use [inventories](../resources/glossary.md#inventory) as unique identifiers for [transactions](../resources/glossary.md#transaction) and [blocks](../resources/glossary.md#block).  Inventories have a simple 36-byte structure:
 
@@ -621,7 +621,7 @@ As seen in the annotated hexdump above, the [`merkleblock` message](../reference
 
 You can use the transaction count to construct an empty [merkle tree](../resources/glossary.md#merkle-tree). We'll call each entry in the tree a node; on the bottom are TXID nodes---the hashes for these nodes are [TXIDs](../resources/glossary.md#transaction-identifiers); the remaining nodes (including the [merkle root](../resources/glossary.md#merkle-root)) are non-TXID nodes---they may actually have the same hash as a TXID, but we treat them differently.
 
-![Example Of Parsing A MerkleBlock Message](https://raw.githubusercontent.com/dashpay/docs-core/main/img/dev/animated-en-merkleblock-parsing.gif)
+![Example Of Parsing A MerkleBlock Message](../../img/dev/animated-en-merkleblock-parsing.gif)
 
 Keep the hashes and flags in the order they appear in the [`merkleblock` message](../reference/p2p-network-data-messages.md#merkleblock). When we say "next flag" or "next hash", we mean the next flag or hash on the list, even if it's the first one we've used so far.
 
@@ -658,7 +658,7 @@ It's easier to understand how to create a [`merkleblock` message](../reference/p
 
 Create a complete merkle tree with [TXIDs](../resources/glossary.md#transaction-identifiers) on the bottom row and all the other hashes calculated up to the [merkle root](../resources/glossary.md#merkle-root) on the top row. For each transaction that matches the filter, track its TXID node and all of its ancestor nodes.
 
-![Example Of Creating A MerkleBlock Message](https://raw.githubusercontent.com/dashpay/docs-core/main/img/dev/animated-en-merkleblock-creation.gif)
+![Example Of Creating A MerkleBlock Message](../../img/dev/animated-en-merkleblock-creation.gif)
 
 Start processing the tree with the [merkle root](../resources/glossary.md#merkle-root) node. The table below describes how to process both TXID nodes and non-TXID nodes based on whether the node is a match, a match ancestor, or neither a match nor a match ancestor.
 

--- a/docs/reference/p2p-network-governance-messages.md
+++ b/docs/reference/p2p-network-governance-messages.md
@@ -2,7 +2,7 @@
 
 The following [network](../resources/glossary.md#network) messages enable the Governance features built in to Dash. For additional details on the governance system, see this [Budget System page](https://docs.dash.org/en/stable/governance/index.html).
 
-![Overview Of P2P Protocol Governance Request And Reply Messages](https://raw.githubusercontent.com/dashpay/docs-core/main/img/dev/en-p2p-governance-messages.svg)
+![Overview Of P2P Protocol Governance Request And Reply Messages](../../img/dev/en-p2p-governance-messages.svg)
 
 For additional details, refer to the Developer Guide [Governance section](../guide/dash-features-governance.md).
 

--- a/docs/reference/p2p-network-masternode-messages.md
+++ b/docs/reference/p2p-network-masternode-messages.md
@@ -2,7 +2,7 @@
 
 The following network messages enable the [masternode](../resources/glossary.md#masternode) features built in to Dash.
 
-![Overview Of P2P Protocol Masternode Request And Reply Messages](https://raw.githubusercontent.com/dashpay/docs-core/main/img/dev/en-p2p-masternode-messages.svg)
+![Overview Of P2P Protocol Masternode Request And Reply Messages](../../img/dev/en-p2p-masternode-messages.svg)
 
 For additional details, refer to the Developer Guide [Masternode Sync](../guide/dash-features-masternode-sync.md) and [Masternode Payment](../guide/dash-features-masternode-payment.md) sections.
 

--- a/docs/reference/p2p-network-privatesend-messages.md
+++ b/docs/reference/p2p-network-privatesend-messages.md
@@ -4,7 +4,7 @@ The following network messages all help control the CoinJoin features built into
 
 Since the messages are all related to a single process, this diagram shows them sequentially numbered. The [`dssu` message](../reference/p2p-network-privatesend-messages.md#dssu) (not shown) is sent by the masternode in conjunction with some responses. For additional details, refer to the Developer Guide [CoinJoin section](../guide/dash-features-coinjoin.md).
 
-![Overview Of P2P Protocol PrivateSend Request And Reply Messages](https://raw.githubusercontent.com/dashpay/docs-core/main/img/dev/en-p2p-privatesend-messages.svg)
+![Overview Of P2P Protocol PrivateSend Request And Reply Messages](../../img/dev/en-p2p-privatesend-messages.svg)
 
 ## dsa
 

--- a/docs/reference/transactions-opcodes.md
+++ b/docs/reference/transactions-opcodes.md
@@ -68,11 +68,11 @@ Several opcodes were disabled in the Bitcoin scripting system due to the discove
 
 ### Signature Script Modification
 
-![Warning icon](https://raw.githubusercontent.com/dashpay/docs-core/main/img/icons/icon_warning.svg) **<span id="signature_script_modification_warning">Signature script modification warning</span>:** [Signature scripts](../resources/glossary.md#signature-script) are not signed, so anyone can modify them. This means signature scripts should only contain data and [data-pushing opcode](../resources/glossary.md#data-pushing-opcode) which can't be modified without causing the pubkey script to fail. Placing non-data-pushing opcodes in the signature script currently makes a transaction non-standard, and future consensus rules may forbid such transactions altogether. (Non-data-pushing opcodes are already forbidden in signature scripts when spending a [P2SH pubkey script](../resources/glossary.md#p2sh-pubkey-script).)
+![Warning icon](../../img/icons/icon_warning.svg) **<span id="signature_script_modification_warning">Signature script modification warning</span>:** [Signature scripts](../resources/glossary.md#signature-script) are not signed, so anyone can modify them. This means signature scripts should only contain data and [data-pushing opcode](../resources/glossary.md#data-pushing-opcode) which can't be modified without causing the pubkey script to fail. Placing non-data-pushing opcodes in the signature script currently makes a transaction non-standard, and future consensus rules may forbid such transactions altogether. (Non-data-pushing opcodes are already forbidden in signature scripts when spending a [P2SH pubkey script](../resources/glossary.md#p2sh-pubkey-script).)
 
 ### Multisig Signature Order
 
-![Warning icon](https://raw.githubusercontent.com/dashpay/docs-core/main/img/icons/icon_warning.svg) **`OP_CHECKMULTISIG` warning:** The [multisig](../resources/glossary.md#multisig) verification process described above requires that signatures in the signature script be provided in the same order as their corresponding public keys in the pubkey script or redeem script. For example, the following combined signature and pubkey script will produce the stack and comparisons shown:
+![Warning icon](../../img/icons/icon_warning.svg) **`OP_CHECKMULTISIG` warning:** The [multisig](../resources/glossary.md#multisig) verification process described above requires that signatures in the signature script be provided in the same order as their corresponding public keys in the pubkey script or redeem script. For example, the following combined signature and pubkey script will produce the stack and comparisons shown:
 
 ``` text
 OP_0 <A sig> <B sig> OP_2 <A pubkey> <B pubkey> <C pubkey> OP_3

--- a/docs/reference/wallets.md
+++ b/docs/reference/wallets.md
@@ -8,6 +8,6 @@ A Type 1 deterministic [wallet](../resources/glossary.md#wallet) is the simpler 
 
 ### Type 2: Hierarchical Deterministic (HD) Wallets
 
-![Overview Of Hierarchical Deterministic Key Derivation](https://raw.githubusercontent.com/dashpay/docs-core/main/img/dev/en-hd-overview.svg)
+![Overview Of Hierarchical Deterministic Key Derivation](../../img/dev/en-hd-overview.svg)
 
 For an overview of the [HD wallet](../resources/glossary.md#hd-wallet), please see the [developer guide section](../guide/wallets.md).  For details, please see [BIP32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki).


### PR DESCRIPTION
I realized shortly after merging #30 that we could just reference the images locally from the `img/*` directories :see_no_evil: This is much better since it doesn't depend on anything being present in `main` before being used elsewhere. And also the images will be located in the build output and won't be dependent on GitHub being online.

<!-- Replace -->
Preview build: https://dash-docs--31.org.readthedocs.build/projects/core/en/31/
<!-- Replace -->
