### PR TITLE
docs: correct formatting around eval-rst

### DIFF
--- a/docs/guide/dash-features-proof-of-service.md
+++ b/docs/guide/dash-features-proof-of-service.md
@@ -1,8 +1,10 @@
 # Proof of Service
+
 ```{eval-rst}
 .. meta::
   :title: Dash Proof of Service
-  :description: The Proof of Service (PoSe) scoring system motivates masternodes to deliver network services, penalizing non-participation by increasing PoSe scores and eventually disqualifying them from payment eligibility. 
+  :description: The Proof of Service (PoSe) scoring system motivates masternodes to deliver network services, penalizing non-participation by increasing PoSe scores and eventually disqualifying them from payment eligibility.
+```
 
 The Proof of Service (PoSe) scoring system helps incentivize [masternodes](../resources/glossary.md#masternode) to provide [network](../resources/glossary.md#network) services. Masternodes that neglect to participate receive an increased PoSe score which eventually results in them being excluded from masternode payment eligibility.
 


### PR DESCRIPTION
We messed up formatting here when working on meta. This corrects it.

<!-- Replace -->
Preview build: https://dash-docs--43.org.readthedocs.build/projects/core/en/43/
<!-- Replace -->
