### PR TITLE
feat: add readthedocs-sphinx-search

### DIFF
--- a/_static/css/pydata-overrides.css
+++ b/_static/css/pydata-overrides.css
@@ -119,3 +119,15 @@ sphinx search extension interface.
 .search__result__content, .search__result__subheading {
   color: var(--pst-color-text-base);
 }
+
+.search__result__subheading span {
+  border-bottom-color: var(--pst-color-text-base);
+}
+
+[data-theme="dark"] .search__outer .search__result__content span {
+  background-color: var(--pst-color-muted-highlight); /* Dark mode background color */
+}
+
+.search__outer .search__result__content span {
+  border-bottom-color: var(--pst-color-text-base);
+}

--- a/_static/css/pydata-overrides.css
+++ b/_static/css/pydata-overrides.css
@@ -124,10 +124,12 @@ sphinx search extension interface.
   border-bottom-color: var(--pst-color-text-base);
 }
 
-[data-theme="dark"] .search__outer .search__result__content span {
+[data-theme="dark"] .search__outer .search__result__content span,
+[data-theme="dark"] .search__outer .search__result__title span {
   background-color: var(--pst-color-muted-highlight); /* Dark mode background color */
 }
 
-.search__outer .search__result__content span {
+.search__outer .search__result__content span,
+.search__outer .search__result__title span {
   border-bottom-color: var(--pst-color-text-base);
 }

--- a/_static/css/pydata-overrides.css
+++ b/_static/css/pydata-overrides.css
@@ -133,3 +133,14 @@ sphinx search extension interface.
 .search__outer .search__result__title span {
   border-bottom-color: var(--pst-color-text-base);
 }
+
+.search__cross__img {
+  /* Make sure "X" remains visible */
+  fill: var(--pst-color-text-base);
+}
+
+.outer_div_page_results:hover, .search__result__box .active {
+  /* Prevent hover from actually changing the color by setting it to what it
+  already is */
+  background-color: var(--pst-color-on-background);
+}

--- a/_static/css/pydata-overrides.css
+++ b/_static/css/pydata-overrides.css
@@ -119,7 +119,7 @@ sphinx search extension interface.
   color: var(--pst-color-link);
 }
 
-.search__result__content, .search__result__subheading {
+.search__result__content, .search__result__subheading, .search__error__box {
   color: var(--pst-color-text-base);
 }
 

--- a/_static/css/pydata-overrides.css
+++ b/_static/css/pydata-overrides.css
@@ -116,6 +116,6 @@ sphinx search extension interface.
   color: var(--pst-color-text-base);
 }
 
-.search__result__content .search__result__subheading {
+.search__result__content, .search__result__subheading {
   color: var(--pst-color-text-base);
 }

--- a/_static/css/pydata-overrides.css
+++ b/_static/css/pydata-overrides.css
@@ -92,6 +92,12 @@ sphinx search extension interface.
   display: none;
 }
 
+/* Make sure it doesn't stick out on the sides of the RtD search screen */
+.search-button__wrapper.show .search-button__search-container {
+    width: 15%;
+}
+
+/* Handle actual styling of the RtD search extension's screen */
 .search__outer {
   background-color: var(--pst-color-on-background);
   border: var(--pst-color-border);
@@ -131,13 +137,15 @@ sphinx search extension interface.
   border-bottom-color: var(--pst-color-text-base);
 }
 
+/* Make sure "X" remains visible */
 .search__cross__img {
-  /* Make sure "X" remains visible */
   fill: var(--pst-color-text-base);
 }
 
-.outer_div_page_results:hover, .search__result__box .active {
-  /* Prevent hover from actually changing the color by setting it to what it
+/* Prevent hover from actually changing the color by setting it to what it
   already is */
+.outer_div_page_results:hover, .search__result__box .active {
   background-color: var(--pst-color-on-background);
 }
+
+/* End of styling of the RtD search extension's screen */

--- a/_static/css/pydata-overrides.css
+++ b/_static/css/pydata-overrides.css
@@ -91,3 +91,26 @@ sphinx search extension interface.
 .search-button__wrapper.show .search-button__overlay {
   display: none;
 }
+
+.search__outer {
+  background-color: var(--pst-color-on-background);
+  border: var(--pst-color-border);
+  border-radius: 0.25em;
+}
+
+.search__outer__input {
+  background-color: var(--pst-color-on-background);
+  font-size: var(--pst-font-size-icon);
+}
+
+.rtd__search__credits {
+  background-color: var(--pst-color-background);
+  color: var(--pst-color-text-muted);
+  .a {
+    color: var(--dash-blue);
+  }
+}
+
+.search__outer__input {
+  color: var(--pst-color-text-base);
+}

--- a/_static/css/pydata-overrides.css
+++ b/_static/css/pydata-overrides.css
@@ -114,3 +114,7 @@ sphinx search extension interface.
 .search__outer__input {
   color: var(--pst-color-text-base);
 }
+
+.search__result__content .search__result__subheading {
+  color: var(--pst-color-text-base);
+}

--- a/_static/css/pydata-overrides.css
+++ b/_static/css/pydata-overrides.css
@@ -106,9 +106,10 @@ sphinx search extension interface.
 .rtd__search__credits {
   background-color: var(--pst-color-background);
   color: var(--pst-color-text-muted);
-  .a {
-    color: var(--dash-blue);
-  }
+}
+
+.rtd__search__credits a {
+  color: var(--pst-color-link);
 }
 
 .search__outer__input {

--- a/_static/css/pydata-overrides.css
+++ b/_static/css/pydata-overrides.css
@@ -80,3 +80,14 @@ tbody tr:nth-child(even) { background-color: var(--table-bg-color-even); }
   vertical-align: middle;
 }
 
+/* These are hacks to hide the pydata-theme search popup behind the readthedocs
+sphinx search extension interface.
+*/
+.search-button__wrapper.show .search-button__search-container,
+.search-button__wrapper.show .search-button__overlay {
+  z-index: 1;
+}
+
+.search-button__wrapper.show .search-button__overlay {
+  display: none;
+}

--- a/_static/css/pydata-overrides.css
+++ b/_static/css/pydata-overrides.css
@@ -100,6 +100,7 @@ sphinx search extension interface.
 
 .search__outer__input {
   background-color: var(--pst-color-on-background);
+  color: var(--pst-color-text-base);
   font-size: var(--pst-font-size-icon);
 }
 
@@ -110,10 +111,6 @@ sphinx search extension interface.
 
 .rtd__search__credits a {
   color: var(--pst-color-link);
-}
-
-.search__outer__input {
-  color: var(--pst-color-text-base);
 }
 
 .search__result__content, .search__result__subheading {

--- a/_static/js/pydata-search-close.js
+++ b/_static/js/pydata-search-close.js
@@ -1,0 +1,82 @@
+// Script to allow use of readthedocs-sphinx-search extension with the pydata
+// theme
+//
+// Based in part on:
+// https://github.com/pydata/pydata-sphinx-theme/blob/v0.13.3/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js#L167-L272
+
+/*******************************************************************************
+ * Search
+ */
+/** Find any search forms on the page and return their input element */
+var findSearchInput = () => {
+  let forms = document.querySelectorAll("form.bd-search");
+  if (!forms.length) {
+    // no search form found
+    return;
+  } else {
+    var form;
+    if (forms.length == 1) {
+      // there is exactly one search form (persistent or hidden)
+      form = forms[0];
+    } else {
+      // must be at least one persistent form, use the first persistent one
+      form = document.querySelector(
+        "div:not(.search-button__search-container) > form.bd-search"
+      );
+    }
+    return form.querySelector("input");
+  }
+};
+
+/** Function to hide the search field */
+var hideSearchField = () => {
+ 
+  let input = findSearchInput();
+  let searchPopupWrapper = document.querySelector(".search-button__wrapper");
+  let hiddenInput = searchPopupWrapper.querySelector("input");
+  
+  if (input === hiddenInput) {
+    searchPopupWrapper.classList.remove("show");
+  }
+  
+  if (document.activeElement === input) {
+    input.blur();
+  }
+};
+
+/** Add an event listener for hideSearchField() for Escape*/
+var addEventListenerForSearchKeyboard = () => {
+  window.addEventListener(
+    "keydown",
+    (event) => {
+      // Allow Escape key to hide the search field
+      if (event.code == "Escape") {
+        hideSearchField();
+      }
+    },
+    true
+  );
+};
+
+/** Activate callbacks for search button popup */
+var setupSearchButtons = () => {
+  addEventListenerForSearchKeyboard();
+};
+
+// Custom code to manage closing the RtD search dialog properly
+$(document).ready(function(){
+  $(".search__cross").click(function(){
+    hideSearchField();
+  });
+  $(".search__outer__wrapper.search__backdrop").click(function(){
+    hideSearchField();
+  });
+  $(".search-button__overlay").click(function(){
+    // Shouldn't be necessary since it's currently hidden by CSS, but just in
+    // case
+    console.log("Close by search-button__overlay");
+    hideSearchField();
+  });
+});
+
+$(setupSearchButtons);

--- a/conf.py
+++ b/conf.py
@@ -28,6 +28,7 @@ extensions = [
   'sphinx.ext.autodoc',
   'sphinx_copybutton',
   'sphinx_design',
+  'sphinx_search.extension',
   'sphinx.ext.intersphinx',
 ]
 
@@ -130,3 +131,6 @@ html_context = {
     "github_version": "19.0.0",
     "doc_path": "",
 }
+
+def setup(app):
+    app.add_js_file('js/pydata-search-close.js')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 Babel==2.12.1
 myst-parser==1.0.0
 pydata-sphinx-theme==0.12.0
+readthedocs-sphinx-search==0.3.1
 sphinx==5.3.0
 sphinx-copybutton==0.5.2
 sphinx-hoverxref==1.3.0


### PR DESCRIPTION
Replace pydata theme's built-in search with search as you type
Note: for an unknown reason, the PR build doesn't actually have functional search. It can be previewed on this build of the branch itself which does work and is presumably reflective of how it will actually work when merged: https://dash-user-docs.readthedocs.io/projects/core/en/v19-rtd-sphinx-search

https://dash-docs--50.org.readthedocs.build/projects/core/en/50/