### PR TITLE
docs(rpc): add wipewallettxes

### DIFF
--- a/docs/api/remote-procedure-call-quick-reference.md
+++ b/docs/api/remote-procedure-call-quick-reference.md
@@ -209,6 +209,7 @@ These RPCs are all Dash-specific and not found in Bitcoin Core
 * [WalletPassphrase](../api/remote-procedure-calls-wallet.md#walletpassphrase): stores the wallet decryption key in memory for the indicated number of seconds. Issuing the `walletpassphrase` command while the wallet is already unlocked will set a new unlock time that overrides the old one.
 * [WalletPassphraseChange](../api/remote-procedure-calls-wallet.md#walletpassphrasechange): changes the wallet passphrase from 'old passphrase' to 'new passphrase'.
 * [WalletProcessPSBT](../api/remote-procedure-calls-wallet.md#walletprocesspsbt): updates a PSBT with input information from a wallet and then allows the signing of inputs. **Updated in Dash Core 18.2.0**
+* [WipeWalletTxes](../api/remote-procedure-calls-wallet.md#wipewallettxes): wipes wallet transactions. **New in Dash Core 19.3.0**
 
 ## [Wallet RPCs (Deprecated)](../api/remote-procedure-calls-wallet-deprecated.md)
 

--- a/docs/api/remote-procedure-calls-wallet.md
+++ b/docs/api/remote-procedure-calls-wallet.md
@@ -3584,3 +3584,31 @@ _See also_
 * [DecodePSBT](../api/remote-procedure-calls-raw-transactions.md#decodepsbt): returns a JSON object representing the serialized, base64-encoded partially signed Dash transaction.
 * [FinalizePSBT](../api/remote-procedure-calls-raw-transactions.md#finalizepsbt): finalizes the inputs of a PSBT.
 * [WalletCreateFundedPSBT](../api/remote-procedure-calls-wallet.md#walletcreatefundedpsbt): creates and funds a transaction in the Partially Signed Transaction (PST) format.
+
+## WipeWalletTxes
+
+The [`wipewallettxes` RPC](../api/remote-procedure-calls-wallet.md#wipewallettxes) wipes all transaction from the wallet. Note: Use the [`rescanblockchain` RPC](../api/remote-procedure-calls-wallet.md#rescanblockchain) to initiate the scanning progress and recover wallet transactions.
+
+_Parameter #1---Keep confirmed txes_
+
+| Name   | Type   | Presence                | Description                   |
+| ------ | ------ | ----------------------- | ----------------------------- |
+| `keep_confirmed` | boolean | Optional<br>(0 or 1) | Do not wipe confirmed transactions (default=`false`) |
+
+_Result---`null` on success_
+
+| Name     | Type | Presence                | Description                                                         |
+| -------- | ---- | ----------------------- | ------------------------------------------------------------------- |
+| `result` | null | Required<br>(exactly 1) | JSON `null` when the transaction and all descendants were abandoned |
+
+_Example from Dash Core 20.0.0_
+
+Wipe all transactions from the wallet:
+
+```bash
+dash-cli -testnet wipewallettxes
+```
+
+_See also_
+
+* [RescanBlockchain](../api/remote-procedure-calls-wallet.md#rescanblockchain): rescans the local blockchain for wallet related transactions.


### PR DESCRIPTION
Adds the `wipewallettxes` RPC added in 19.3

Preview build: https://dash-docs--56.org.readthedocs.build/projects/core/en/56/docs/api/remote-procedure-calls-wallet.html#wipewallettxes