### PR TITLE
docs: v20 p2p updates, part 1

### DIFF
--- a/docs/reference/p2p-network-control-messages.md
+++ b/docs/reference/p2p-network-control-messages.md
@@ -499,7 +499,7 @@ The following service identifiers have been assigned.
 |-------|--------------|---------------
 | 0x00  | *Unnamed*    | This node is not a full node.  It may not be able to provide any data except for the transactions it originates.
 | 0x01  | `NODE_NETWORK` | This is a full node and can be asked for full blocks.  It should implement all protocol features available in its self-reported protocol version.
-| 0x02  | `NODE_GETUTXO` | This node is capable of responding to the getutxo protocol request. *Dash Core does not support this service.*
+| 0x02  | `NODE_GETUTXO` | **Removed in Dash Core 20.0.0**<br>This node is capable of responding to the getutxo protocol request.
 | 0x04  | `NODE_BLOOM` | This node is capable and willing to handle bloom-filtered connections.  Dash Core nodes used to support this by default, without advertising this bit, but no longer do as of protocol version 70201 (= NO_BLOOM_VERSION)
 | 0x08 | `NODE_XTHIN` | This node supports Xtreme Thinblocks. *Dash Core does not support this service.*
 | 0x400 | `NODE_NETWORK_LIMITED` | This is the same as `NODE_NETWORK` with the limitation of only serving the last 288 blocks. *Not supported prior to Dash Core 0.16.0*

--- a/docs/reference/p2p-network-data-messages.md
+++ b/docs/reference/p2p-network-data-messages.md
@@ -24,7 +24,6 @@ The currently-available type identifiers are:
 | 1               | MSG_TX                                     | The hash is a TXID.
 | 2               | MSG_BLOCK                            | The hash is of a block header.
 | 3               | MSG_FILTERED_BLOCK | The hash is of a block header; identical to `MSG_BLOCK`. When used in a [`getdata` message](../reference/p2p-network-data-messages.md#getdata), this indicates the response should be a [`merkleblock` message](../reference/p2p-network-data-messages.md#merkleblock) rather than a [`block` message](../reference/p2p-network-data-messages.md#block) (but this only works if a bloom filter was previously configured).  **Only for use in [`getdata` messages](../reference/p2p-network-data-messages.md#getdata).**
-| 4               | MSG_LEGACY_TXLOCK_REQUEST | `MSG_TXLOCK_REQUEST` prior to Dash Core 0.15.0. The hash is an Instant Send transaction lock request. Transactions received this way are automatically converted to a standard [`tx` message](../reference/p2p-network-data-messages.md#tx) as of Dash Core 0.15.0.
 | 6               | MSG_SPORK                            | The hash is Spork ID.
 | 16              | MSG_DSTX                              | The hash is CoinJoin Broadcast TX.
 | 17               | MSG_GOVERNANCE_OBJECT                                     | The hash is a Governance Object.
@@ -46,7 +45,8 @@ The following type identifiers have been deprecated recently. To see type identi
 
 | Type Identifier | Name                                                                          | Description
 |-----------------|-------------------------------------------------------------------------------|---------------
-| 5               | MSG_TXLOCK_VOTE          | **Deprecated in 0.15.0**<br><br>The hash is an Instant Send transaction vote.
+| 4               | MSG_LEGACY_TXLOCK_REQUEST | **Deprecated in 20.0.0**<br><br>`MSG_TXLOCK_REQUEST` prior to Dash Core 0.15.0. The hash is an InstantSend transaction lock request. Transactions received this way are automatically converted to a standard [`tx` message](../reference/p2p-network-data-messages.md#tx) as of Dash Core 0.15.0.
+| 5               | MSG_TXLOCK_VOTE          | **Deprecated in 0.15.0**<br><br>The hash is an InstantSend transaction vote.
 
 Type identifier zero and type identifiers greater than those shown in the table above are reserved for future implementations. Dash Core ignores all inventories with one of these unknown types.
 

--- a/docs/reference/p2p-network-data-messages.md
+++ b/docs/reference/p2p-network-data-messages.md
@@ -705,6 +705,8 @@ The [`mnlistdiff` message](../reference/p2p-network-data-messages.md#mnlistdiff)
 | variable | deletedQuorums | (uint8_t+uint256)[] | Required | _Added in protocol version 70214_<br><br>A list of LLMQ type and quorum hashes for LLMQs which were deleted after `baseBlockHash` |
 | 1-9 | newQuorumsCount | compactSize uint | Required | _Added in protocol version 70214_<br><br>Number of new LLMQs which were added to the active set since `baseBlockHash` |
 | variable | newQuorums | qfcommit[] | Required | _Added in protocol version 70214_<br><br>The list of LLMQ commitments for the LLMQs which were added since `baseBlockHash` |
+|  1-9 | quorumsCLSigsCount | compactSize uint | Required | _Added in protocol version 70230_<br><br>Number of `quorumsCLSigs` elements |
+| variable | quorumsCLSigs | quorumsCLSigsObject[] | Required | _Added in protocol version 70230_<br><br>ChainLock signature used to calculate members per quorum indexes (in `newQuorums`) |
 
 Simplified Masternode List (SML) Entry
 
@@ -721,6 +723,14 @@ Simplified Masternode List (SML) Entry
 | 1 | isValid | bool | True if a masternode is not PoSe-banned
 | 0 or 2 | platformHTTPPort | uint_16 | TCP port of Platform HTTP/API interface (network byte order).<br>**Note**: Only present when mnlistdiff `version` is 2 and `type` is 1. |
 0 or 20 | platformNodeID | byte[] | Dash Platform P2P node ID, derived from P2P public key.<br>**Note**: Only present when mnlistdiff `version` is 2 and `type` is 1. |
+
+The content of `quorumsCLSigsObject`:
+
+| Bytes | Name | Data type | Description |
+| - | - | - | - |
+| 96 | signature | BLSSig | ChainLock signature |
+| 1-9 | indexSetCount | compactSize uint | Number of quorum indexes using the same `signature` for their member calculation |
+| uint16_t[] | indexSet | variable | Quorum indexes corresponding in `newQuorums` using `signature` for their member calculation |
 
 The following annotated hexdump shows a [`mnlistdiff` message](../reference/p2p-network-data-messages.md#mnlistdiff). (The message header has been omitted.)
 

--- a/docs/reference/p2p-network-data-messages.md
+++ b/docs/reference/p2p-network-data-messages.md
@@ -41,7 +41,7 @@ The currently-available type identifiers are:
 
 **Deprecated Type Identifiers**
 
-The following type identifiers have been deprecated recently. To see type identifiers removed longer ago, please see the [previous version of documentation](https://dashcore.readme.io/v0.16.0/docs/core-ref-p2p-network-data-messages).
+The following type identifiers have been deprecated recently. To see type identifiers removed longer ago, please see the [previous version of documentation](https://docs.dash.org/projects/core/en/19.0.0/docs/reference/p2p-network-data-messages.html).
 
 | Type Identifier | Name                                                                          | Description
 |-----------------|-------------------------------------------------------------------------------|---------------

--- a/docs/reference/p2p-network-data-messages.md
+++ b/docs/reference/p2p-network-data-messages.md
@@ -689,7 +689,7 @@ The [`mnlistdiff` message](../reference/p2p-network-data-messages.md#mnlistdiff)
 
 | Bytes | Name | Data<br>type | Required | Description |
 | ---------- | ----------- | --------- | -------- | -------- |
-| 2 | version | uint16_t | Required | **_Updated in protocol version 70228_**<br>Version of the message (currently `1`). |
+| 2 | version | uint16_t | Required | **_Updated in protocol version 70229_**<br>Version of the message (currently `1`).<br>In protocol versions 70225 through 70228 this field was located between the `cbTx` and `deletedMNsCount` fields. |
 | 32 | baseBlockHash | uint256 | Required | Hash of a block the requester already has a valid masternode list of. Can be all-zero to indicate that a full masternode list is requested.
 | 32 | blockHash | uint256 | Required | Hash of the block for which the masternode list diff is requested
 | 4 | totalTransactions | uint32_t  | Required | Number of total transactions in `blockHash`

--- a/docs/reference/transactions-special-transactions.md
+++ b/docs/reference/transactions-special-transactions.md
@@ -689,6 +689,8 @@ The special transaction type used for CbTx Transactions is 5 and the extra paylo
 | 4 | height | uint32_t | Height of the block
 | 32 | merkleRootMNList | uint256 | Merkle root of the masternode list
 | 32 | merkleRootQuorums | uint256 | *Added by CbTx version 2 in v0.14.0*<br><br>Merkle root of currently active LLMQs
+| 4 | bestCLHeightDiff | uint32_t | *Added by CbTx version 3 in v20.0.0*<br><br>Number of blocks between the current block and the last known block with a ChainLock
+| 96 | bestCLSignature | CBLSSignature | Best ChainLock signature known by the miner
 
 Version History
 
@@ -696,6 +698,7 @@ Version History
 | ---------- | ----------- | -------- | -------- |
 | 1 | 70213 | 0.13.0 | Enabled by activation of [DIP3](https://github.com/dashpay/dips/blob/master/dip-0003.md)
 | 2 | 70214 | 0.14.0 | Enabled by activation of [DIP8](https://github.com/dashpay/dips/blob/master/dip-0008.md)
+| 3 | 70230 | 20.0.0 | Enabled by activation of [DIP29](https://github.com/dashpay/dips/blob/master/dip-0029.md)
 
 The following annotated hexdump shows a CbTx transaction.
 

--- a/docs/reference/transactions-special-transactions.md
+++ b/docs/reference/transactions-special-transactions.md
@@ -998,7 +998,7 @@ The JSON representation of a raw transaction can be obtained with the [`getrawtr
 
 ## MnHfTx
 
-*Added in protocol version 70222 of Dash Core as described by [DIP23](https://github.com/dashpay/dips/blob/master/dip-0023.md)*
+*Fully implemented in protocol version 70230 of Dash Core as described by [DIP23](https://github.com/dashpay/dips/blob/master/dip-0023.md)*
 
 > 🚧 Note
 >
@@ -1006,16 +1006,21 @@ The JSON representation of a raw transaction can be obtained with the [`getrawtr
 
 The Masternode Hard Fork Signal (MnHfTx) special transaction adds the masternode hard fork signal produced by an LLMQ_400_85 quorum to the chain. Since this special transaction pays no fees, it is mandatory by consensus rules to ensure that miners include it. This can be done by any miner in any block, but it should only be included once.
 
-> 📘 Partial implementation in Dash Core 18.0
->
-> Dash Core 18.0 only added the special transaction [to prepare for the full implementation](https://github.com/dashpay/dash/issues/4533) of [DIP23](https://github.com/dashpay/dips/blob/master/dip-0023.md) in a future release. The `mnhfsignal` P2P message referenced below is not included in Dash Core 18.0.
-
 The special transaction type used for Quorum Commitment Transactions is 7 and the extra payload consists of the following data:
 
 | Bytes | Name | Data type |  Description |
 | ---------- | ----------- | -------- | -------- |
-| 2 | version | uint_16 | Quorum Commitment version number. Currently set to 1.
-| Variable | commitment | mnhfsignal | The payload of the `mnhfsignal` message (defined in [DIP23](https://github.com/dashpay/dips/blob/master/dip-0023.md#new-system) but not yet implemented)
+| 1 | versionBit | uint_8 | Commitment special transaction version number. Currently set to 1. Please note that this is not the same as the version field of the `mnhfsignal` message.
+| 129 | commitment | mnhfsignal | The payload of the `mnhfsignal` message defined in [DIP23](https://github.com/dashpay/dips/blob/master/dip-0023.md#new-system)
+
+The `mnhfsignal` message contains:
+
+| Bytes | Name | Data type | Description |
+|-|-|-|-|
+| 1 | version | uint8_t | The version bits associated with the hard fork |
+| 1 | versionBit | uint8_t | The version bits associated with the hard fork |
+| 32 | quorumHash | uint256 | Hash of the quorum signing this message |
+| 96 | sig | CBLSSig | BLS signature on `version` by a public key associated with the quorum referenced by `quorumHash` |
 
 The following annotated hexdump shows a MnHfTx transaction.
 

--- a/docs/reference/transactions-special-transactions.md
+++ b/docs/reference/transactions-special-transactions.md
@@ -998,7 +998,7 @@ The JSON representation of a raw transaction can be obtained with the [`getrawtr
 
 ## MnHfTx
 
-*Fully implemented in protocol version 70230 of Dash Core as described by [DIP23](https://github.com/dashpay/dips/blob/master/dip-0023.md)*
+*Added in protocol version 70222 of Dash Core as described by [DIP23](https://github.com/dashpay/dips/blob/master/dip-0023.md)*
 
 > 🚧 Note
 >
@@ -1006,21 +1006,16 @@ The JSON representation of a raw transaction can be obtained with the [`getrawtr
 
 The Masternode Hard Fork Signal (MnHfTx) special transaction adds the masternode hard fork signal produced by an LLMQ_400_85 quorum to the chain. Since this special transaction pays no fees, it is mandatory by consensus rules to ensure that miners include it. This can be done by any miner in any block, but it should only be included once.
 
+> 📘 Partial implementation in Dash Core 18.0
+>
+> Dash Core 18.0 only added the special transaction [to prepare for the full implementation](https://github.com/dashpay/dash/issues/4533) of [DIP23](https://github.com/dashpay/dips/blob/master/dip-0023.md) in a future release. The `mnhfsignal` P2P message referenced below is not included in Dash Core 18.0.
+
 The special transaction type used for Quorum Commitment Transactions is 7 and the extra payload consists of the following data:
 
 | Bytes | Name | Data type |  Description |
 | ---------- | ----------- | -------- | -------- |
-| 1 | versionBit | uint_8 | Commitment special transaction version number. Currently set to 1. Please note that this is not the same as the version field of the `mnhfsignal` message.
-| 129 | commitment | mnhfsignal | The payload of the `mnhfsignal` message defined in [DIP23](https://github.com/dashpay/dips/blob/master/dip-0023.md#new-system)
-
-The `mnhfsignal` message contains:
-
-| Bytes | Name | Data type | Description |
-|-|-|-|-|
-| 1 | version | uint8_t | The version bits associated with the hard fork |
-| 1 | versionBit | uint8_t | The version bits associated with the hard fork |
-| 32 | quorumHash | uint256 | Hash of the quorum signing this message |
-| 96 | sig | CBLSSig | BLS signature on `version` by a public key associated with the quorum referenced by `quorumHash` |
+| 2 | version | uint_16 | Quorum Commitment version number. Currently set to 1.
+| Variable | commitment | mnhfsignal | The payload of the `mnhfsignal` message (defined in [DIP23](https://github.com/dashpay/dips/blob/master/dip-0023.md#new-system) but not yet implemented)
 
 The following annotated hexdump shows a MnHfTx transaction.
 


### PR DESCRIPTION
Initial updates related to Dash Core v20 p2p updates. Does not include asset lock info.

<!-- Replace -->
Preview build: https://dash-docs--63.org.readthedocs.build/projects/core/en/63/
<!-- Replace -->
