### PR TITLE
feat: update platform docs links

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ information to help you start working with Dash as quickly as possible. This
 core developer documentation is available at
 https://docs.dash.org/projects/core, while user documentation is maintained at
 https://docs.dash.org/ and Platform developer documentation at
-https://dashplatform.readme.io/.
+https://docs.dash.org/projects/platform.
 
 ## Contributing
 

--- a/_templates/sidebar-main.html
+++ b/_templates/sidebar-main.html
@@ -416,17 +416,17 @@
                 <ul class="nav bd-sidenav">
 
                     <li class="toctree-l1"><a class="reference internal"
-                            href="https://dashplatform.readme.io/docs/introduction-what-is-dash-platform">Introduction</a>
+                            href="https://docs.dash.org/projects/platform/en/stable/docs/intro/what-is-dash-platform.html">Introduction</a>
                     </li>
                     <li class="toctree-l1"><a class="reference internal"
-                            href="https://dashplatform.readme.io/docs/tutorials-introduction">Tutorials</a>
+                            href="https://docs.dash.org/projects/platform/en/stable/docs/tutorials/introduction.html">Tutorials</a>
                     </li>
                     <li class="toctree-l1"><a class="reference internal"
-                            href="https://dashplatform.readme.io/docs/explanation-dapi">Explanations</a></li>
+                            href="https://docs.dash.org/projects/platform/en/stable/docs/explanations/dapi.html">Explanations</a></li>
                     <li class="toctree-l1"><a class="reference internal"
-                            href="https://dashplatform.readme.io/docs/reference-dapi-endpoints">Reference</a></li>
+                            href="https://docs.dash.org/projects/platform/en/stable/docs/reference/dapi-endpoints.html">Reference</a></li>
                     <li class="toctree-l1"><a class="reference internal"
-                            href="https://dashplatform.readme.io/docs/platform-protocol-reference-overview">Platform
+                            href="https://docs.dash.org/projects/platform/en/stable/docs/protocol-ref/overview.html">Platform
                             Protocol</a></li>
                     </li>
 

--- a/conf.py
+++ b/conf.py
@@ -65,6 +65,7 @@ myst_enable_extensions = ["colon_fence"]
 # -- intersphinx configuration -----------------------------------------------
 intersphinx_mapping = {
     "user": ("https://docs.dash.org/en/stable/", None),
+    "platform": ("https://docs.dash.org/projects/platform/en/stable/", None),
 }
 
 # We recommend adding the following config value.
@@ -97,7 +98,7 @@ html_sidebars = {
 html_theme_options = {
 #    "announcement": "Test build of Dash Core documentation migrated from <a href='https://dashcore.readme.io'>Readme.io</a>!",
     "external_links": [
-        {"name": "Platform docs", "url": "https://dashplatform.readme.io"},
+        {"name": "Platform docs", "url": "https://docs.dash.org/projects/platform/en/stable/docs/index.html"},
         {"name": "User docs", "url": "https://docs.dash.org/"},        
         {"name": "Dash.org", "url": "https://www.dash.org"},
         {"name": "Forum", "url": "https://www.dash.org/forum"},

--- a/docs/guide/dash-features.md
+++ b/docs/guide/dash-features.md
@@ -26,7 +26,7 @@ However, the Dash network has a second layer of network participants that provid
 >
 > New in Dash Core v19.0
 
-Evolution Masternodes (evonodes) are a new type of masternode created to host [Dash Platform](https://dashplatform.readme.io/docs/introduction-what-is-dash-platform) – a Web3 technology stack for building decentralized applications on the Dash network. The collateral required to own an evonode is 4000 DASH, as opposed to 1000 DASH for regular masternodes.
+Evolution Masternodes (evonodes) are a new type of masternode created to host [Dash Platform](inv:platform:std#intro-dash-platform) – a Web3 technology stack for building decentralized applications on the Dash network. The collateral required to own an evonode is 4000 DASH, as opposed to 1000 DASH for regular masternodes.
 
 Evonodes serve Platform along with Core, while regular masternodes only serve Core. The recommended specs for evonodes are higher than those for regular masternodes. Evonodes will receive 100% of the fees generated from Platform and 37.5% of the masternode portion of Core block rewards. Regular MNs will receive the remaining 62.5% of the masternode portion of Core block rewards and 0% of Platform fees.
 

--- a/index.md
+++ b/index.md
@@ -51,7 +51,7 @@ Check out the `official Dash website <https://www.dash.org/>`__ to learn how
          Start working with Dash Platform and discover how you can use its powerful capabilities to power your Web3 project.
          
          +++
-         `Click to begin <platform:platform-index>`
+         :ref:`Click to begin <platform:platform-index>`
 
 .. _core-reference:
 

--- a/index.md
+++ b/index.md
@@ -45,13 +45,13 @@ Check out the `official Dash website <https://www.dash.org/>`__ to learn how
 
     .. grid-item-card:: 🚀 Platform Docs
          :margin: 2 2 auto auto
-         :link-type: url
-         :link: https://dashplatform.readme.io
+         :link-type: ref
+         :link: platform:platform-index
 
          Start working with Dash Platform and discover how you can use its powerful capabilities to power your Web3 project.
          
          +++
-         `Click to begin <https://dashplatform.readme.io>`__
+         `Click to begin <platform:platform-index>`
 
 .. _core-reference:
 


### PR DESCRIPTION
Switches links from readme.io to docs.dash.org

<!-- Replace -->
Preview build: https://dash-docs--68.org.readthedocs.build/projects/core/en/68/
<!-- Replace -->
