### PR TITLE
docs: v20 cbtx updates

### DIFF
--- a/docs/reference/transactions-special-transactions.md
+++ b/docs/reference/transactions-special-transactions.md
@@ -689,8 +689,8 @@ The special transaction type used for CbTx Transactions is 5 and the extra paylo
 | 4 | height | uint32_t | Height of the block
 | 32 | merkleRootMNList | uint256 | Merkle root of the masternode list
 | 32 | merkleRootQuorums | uint256 | *Added by CbTx version 2 in v0.14.0*<br><br>Merkle root of currently active LLMQs
-| 4 | bestCLHeightDiff | uint32_t | *Added by CbTx version 3 in v20.0.0*<br><br>Number of blocks between the current block and the last known block with a ChainLock
-| 96 | bestCLSignature | CBLSSignature | Best ChainLock signature known by the miner
+| 4 | bestCLHeightDiff | uint32_t | ***Added by CbTx version 3 in v20.0.0***<br><br>Number of blocks between the current block and the last known block with a ChainLock
+| 96 | bestCLSignature | CBLSSignature | ***Added by CbTx version 3 in Dash Core 20.0.0***<br>Best ChainLock signature known by the miner
 
 Version History
 

--- a/docs/reference/transactions-special-transactions.md
+++ b/docs/reference/transactions-special-transactions.md
@@ -761,96 +761,77 @@ Coinbase Transaction Payload
 
 ```Text Raw Transaction hex
 03000500010000000000000000000000000000000000000000000000000000000000000000ffffffff
-12027d1b0e2f5032506f6f6c2d74444153482fffffffff0403155b96010000001976a9144f79c383bc
-5d3e9d4d81b98f87337cedfa78953688ac40c3609a010000001976a914255c0d7c93c12c801140d4e3
-287d2f40d4ff42dd88ac3dae0504000000001976a914badadfdebaa6d015a0299f23fbc1fcbdd72ba9
-6f88ac00000000000000002a6a2883bdbfb92d3848bca649767bf4f1f2994a66026a938d8963486647
-03e730bbce0000000001000000000000002601007d1b00000000000000000000000000000000000000
-000000000000000000000000000000
+060364df0d0101ffffffff02ec846e04000000001976a914c69a0bda7daaae481be8def95e5f347a1d
+00a4b488acc48e4b0d000000001976a914c69a0bda7daaae481be8def95e5f347a1d00a4b488ac0000
+0000af030064df0d00c6c78eb3e36acab63b6e6694530a18ee49fbacaee9ccf3f40a243c38a9a935fc
+ebb785522e0736257fd1655feb0f5a3f4c978e216dec3a07bc4554fe9d14e39b00a269a7696d8284e4
+a4f005bcbfc840b53e314523864f726e183fdef5c9ed6319eb98ac2f398e45859ad4f28cf8ff5dab12
+ec5f4d315a1821b622c983fa387347607dcee338c813f78bcacd4cbf756a40bf61bb5e9a2e5b508a5a
+51f3d7d069f0c8599f8c01000000
 ```
 
 The JSON representation of a raw transaction can be obtained with the [`getrawtransaction` RPC](../api/remote-procedure-calls-raw-transactions.md#getrawtransaction) or the [`decoderawtransaction` RPC](../api/remote-procedure-calls-raw-transactions.md#decoderawtransaction).
 
 ```json JSON Representation
 {
-  "txid": "13c97f347a78eb3c200e224d074207043e419feef46a447b4065add9da90068d",
+  "txid": "46b9a08e934872bb5d54833f3b665853ced210703628bb9e9ff520b062482911",
   "version": 3,
   "type": 5,
-  "size": 261,
+  "size": 301,
   "locktime": 0,
   "vin": [
     {
-      "coinbase": "027d1b0e2f5032506f6f6c2d74444153482f",
+      "coinbase": "0364df0d0101",
       "sequence": 4294967295
     }
   ],
   "vout": [
     {
-      "value": 68.17518851,
-      "valueSat": 6817518851,
+      "value": 0.74351852,
+      "valueSat": 74351852,
       "n": 0,
       "scriptPubKey": {
-        "asm": "OP_DUP OP_HASH160 4f79c383bc5d3e9d4d81b98f87337cedfa789536 OP_EQUALVERIFY OP_CHECKSIG",
-        "hex": "76a9144f79c383bc5d3e9d4d81b98f87337cedfa78953688ac",
+        "asm": "OP_DUP OP_HASH160 c69a0bda7daaae481be8def95e5f347a1d00a4b4 OP_EQUALVERIFY OP_CHECKSIG",
+        "hex": "76a914c69a0bda7daaae481be8def95e5f347a1d00a4b488ac",
         "reqSigs": 1,
         "type": "pubkeyhash",
         "addresses": [
-          "yTZg6eePKxbJZyoaC93bVrTUq5vjhFrbst"
+          "yeRZBWYfeNE4yVUHV4ZLs83Ppn9aMRH57A"
         ]
       }
     },
     {
-      "value": 68.85000000,
-      "valueSat": 6885000000,
+      "value": 2.23055556,
+      "valueSat": 223055556,
       "n": 1,
       "scriptPubKey": {
-        "asm": "OP_DUP OP_HASH160 255c0d7c93c12c801140d4e3287d2f40d4ff42dd OP_EQUALVERIFY OP_CHECKSIG",
-        "hex": "76a914255c0d7c93c12c801140d4e3287d2f40d4ff42dd88ac",
+        "asm": "OP_DUP OP_HASH160 c69a0bda7daaae481be8def95e5f347a1d00a4b4 OP_EQUALVERIFY OP_CHECKSIG",
+        "hex": "76a914c69a0bda7daaae481be8def95e5f347a1d00a4b488ac",
         "reqSigs": 1,
         "type": "pubkeyhash",
         "addresses": [
-          "yPiz8EUxbmddJ8x2bvpqytQpVRfu5CL4xQ"
+          "yeRZBWYfeNE4yVUHV4ZLs83Ppn9aMRH57A"
         ]
-      }
-    },
-    {
-      "value": 0.67481149,
-      "valueSat": 67481149,
-      "n": 2,
-      "scriptPubKey": {
-        "asm": "OP_DUP OP_HASH160 badadfdebaa6d015a0299f23fbc1fcbdd72ba96f OP_EQUALVERIFY OP_CHECKSIG",
-        "hex": "76a914badadfdebaa6d015a0299f23fbc1fcbdd72ba96f88ac",
-        "reqSigs": 1,
-        "type": "pubkeyhash",
-        "addresses": [
-          "ydMSjYqwv4xTossPJ1xndTxwS1Hho9DmuM"
-        ]
-      }
-    },
-    {
-      "value": 0.00000000,
-      "valueSat": 0,
-      "n": 3,
-      "scriptPubKey": {
-        "asm": "OP_RETURN 83bdbfb92d3848bca649767bf4f1f2994a66026a938d896348664703e730bbce0000000001000000",
-        "hex": "6a2883bdbfb92d3848bca649767bf4f1f2994a66026a938d896348664703e730bbce0000000001000000",
-        "type": "nulldata"
       }
     }
   ],
-  "extraPayloadSize": 38,
-  "extraPayload": "01007d1b00000000000000000000000000000000000000000000000000000000000000000000",
+  "extraPayloadSize": 175,
+  "extraPayload": "030064df0d00c6c78eb3e36acab63b6e6694530a18ee49fbacaee9ccf3f40a243c38a9a935fcebb785522e0736257fd1655feb0f5a3f4c978e216dec3a07bc4554fe9d14e39b00a269a7696d8284e4a4f005bcbfc840b53e314523864f726e183fdef5c9ed6319eb98ac2f398e45859ad4f28cf8ff5dab12ec5f4d315a1821b622c983fa387347607dcee338c813f78bcacd4cbf756a40bf61bb5e9a2e5b508a5a51f3d7d069f0c8599f8c01000000",
   "cbTx": {
-    "version": 1,
-    "height": 7037,
-    "merkleRootMNList": "0000000000000000000000000000000000000000000000000000000000000000"
+    "version": 3,
+    "height": 909156,
+    "merkleRootMNList": "fc35a9a9383c240af4f3cce9aeacfb49ee180a5394666e3bb6ca6ae3b38ec7c6",
+    "merkleRootQuorums": "9be3149dfe5445bc073aec6d218e974c3f5a0feb5f65d17f2536072e5285b7eb",
+    "bestCLHeightDiff": 0,
+    "bestCLSignature": "a269a7696d8284e4a4f005bcbfc840b53e314523864f726e183fdef5c9ed6319eb98ac2f398e45859ad4f28cf8ff5dab12ec5f4d315a1821b622c983fa387347607dcee338c813f78bcacd4cbf756a40bf61bb5e9a2e5b508a5a51f3d7d069f0",
+    "creditPoolBalance": 66.54220744
   },
-  "hex": "03000500010000000000000000000000000000000000000000000000000000000000000000ffffffff12027d1b0e2f5032506f6f6c2d74444153482fffffffff0403155b96010000001976a9144f79c383bc5d3e9d4d81b98f87337cedfa78953688ac40c3609a010000001976a914255c0d7c93c12c801140d4e3287d2f40d4ff42dd88ac3dae0504000000001976a914badadfdebaa6d015a0299f23fbc1fcbdd72ba96f88ac00000000000000002a6a2883bdbfb92d3848bca649767bf4f1f2994a66026a938d896348664703e730bbce0000000001000000000000002601007d1b00000000000000000000000000000000000000000000000000000000000000000000",
-  "blockhash": "0000002b387c0a1610bfc87b74e5de3b5a6bd851c0ed50ed2e8dd741da50cea0",
-  "height": 7037,
-  "confirmations": 851586,
-  "time": 1545091336,
-  "blocktime": 1545091336,
+  "hex": "03000500010000000000000000000000000000000000000000000000000000000000000000ffffffff060364df0d0101ffffffff02ec846e04000000001976a914c69a0bda7daaae481be8def95e5f347a1d00a4b488acc48e4b0d000000001976a914c69a0bda7daaae481be8def95e5f347a1d00a4b488ac00000000af030064df0d00c6c78eb3e36acab63b6e6694530a18ee49fbacaee9ccf3f40a243c38a9a935fcebb785522e0736257fd1655feb0f5a3f4c978e216dec3a07bc4554fe9d14e39b00a269a7696d8284e4a4f005bcbfc840b53e314523864f726e183fdef5c9ed6319eb98ac2f398e45859ad4f28cf8ff5dab12ec5f4d315a1821b622c983fa387347607dcee338c813f78bcacd4cbf756a40bf61bb5e9a2e5b508a5a51f3d7d069f0c8599f8c01000000",
+  "blockhash": "0000009adf7b4733d573dd341d5d6e5cc64d82d09fc8fed0e733df09b688c331",
+  "height": 909156,
+  "confirmations": 1,
+  "time": 1699462128,
+  "blocktime": 1699462128,
   "instantlock": true,
   "instantlock_internal": false,
   "chainlock": true

--- a/docs/reference/transactions-special-transactions.md
+++ b/docs/reference/transactions-special-transactions.md
@@ -700,7 +700,7 @@ Version History
 | 2 | 70214 | 0.14.0 | Enabled by activation of [DIP8](https://github.com/dashpay/dips/blob/master/dip-0008.md)
 | 3 | 70230 | 20.0.0 | Enabled by activation of [DIP29](https://github.com/dashpay/dips/blob/master/dip-0029.md)
 
-The following annotated hexdump shows a CbTx transaction.
+The following annotated hexdump shows a CbTx transaction (v3).
 
 An itemized coinbase transaction:
 
@@ -713,39 +713,48 @@ An itemized coinbase transaction:
 | 00000000000000000000000000000000 ......... Previous outpoint TXID
 | ffffffff ................................. Previous outpoint index
 |
-| 4c ....................................... Bytes in coinbase: 76
+| 06 ....................................... Bytes in coinbase: 6
 | |
 | | 03 ..................................... Bytes in height
-| | | 393d01 ............................... Height: 81209
+| | | 64df0d ............................... Height: 909156
 | |
-| | 04b9...6d2f ............................ Arbitrary data (truncated)
-| 00000000 ................................. Sequence
+| | 0101 ................................... Arbitrary data
+| ffffffff ................................. Sequence
 
 02 ......................................... Output count
 | Transaction Output 1
-| | 40230e4300000000 ....................... Duffs (11.25 DASH)
-| | 1976a914b7ce0ea9ce2010f58ba4aaa6
-| | caa76671c438e89088ac ................... Script
+| | ec846e0400000000 ....................... Duffs (0.74351852 DASH)
+| | 1976a914c69a0bda7daaae481be8def9
+| | 5e5f347a1d00a4b488ac ................... Script
 |
 | Transaction Output 2
-| | 40230e4300000000 ....................... Duffs (11.25 DASH)
-| | 1976a91405ea03a6c9dfa67e1837b3c1
-| | 4965ba3cb53bce7288ac ................... P2PKH script
+| | c48e4b0d00000000 ....................... Duffs (2.23055556 DASH)
+| | 1976a914c69a0bda7daaae481be8def9
+| | 5e5f347a1d00a4b488ac ................... P2PKH script
 
 00000000 ................................... Locktime
 
-46 ......................................... Extra payload size (38)
+af ......................................... Extra payload size (175)
 
 Coinbase Transaction Payload
-| 0200 ..................................... Version (2)
+| 0300 ..................................... Version (3)
 |
-| 393d0100 ................................. Block height: 81209
+| 64df0d00 ................................. Block height: 909156
 |
-| e2dd012c5b0b1753cef0e32f978917ef
-| e7a484c5080b31b4e3f966ccc0e0f8dd ......... MN List merkle root
+| c6c78eb3e36acab63b6e6694530a18ee
+| 49fbacaee9ccf3f40a243c38a9a935fc ......... MN List merkle root
 |
-| 2ef709f55fa42cb53d29d75dad77d212
-| fb0bd72a47ecfe0e8aa6f660fb96396e ......... Active LLMQ merkle root
+| ebb785522e0736257fd1655feb0f5a3f
+| 4c978e216dec3a07bc4554fe9d14e39b ......... Active LLMQ merkle root
+|
+| 00a269a7 ................................. Best ChainLock height diff
+|
+| 696d8284e4a4f005bcbfc840b53e3145
+| 23864f726e183fdef5c9ed6319eb98ac
+| 2f398e45859ad4f28cf8ff5dab12ec5f
+| 4d315a1821b622c983fa387347607dce
+| e338c813f78bcacd4cbf756a40bf61bb
+| 5e9a2e5b508a5a51f3d7d069f0c8599f ......... ChainLock BLS signature
 ```
 
 ### Example CbTx

--- a/docs/reference/transactions-special-transactions.md
+++ b/docs/reference/transactions-special-transactions.md
@@ -695,11 +695,11 @@ The special transaction type used for CbTx Transactions is 5 and the extra paylo
 
 Version History
 
-| CbTx Version | First Supported Protocol Version | Dash Core Version |  Notes |
+| CbTx<br>Version | First Supported<br>Protocol Version | Dash Core<br>Version |  Notes |
 | ---------- | ----------- | -------- | -------- |
-| 1 | 70213 | 0.13.0 | Enabled by activation of [DIP3](https://github.com/dashpay/dips/blob/master/dip-0003.md)
-| 2 | 70214 | 0.14.0 | Enabled by activation of [DIP8](https://github.com/dashpay/dips/blob/master/dip-0008.md)
-| 3 | 70230 | 20.0.0 | Enabled by activation of [DIP29](https://github.com/dashpay/dips/blob/master/dip-0029.md)
+| 1 | 70213 | 0.13.0 | Enabled by [DIP3](https://github.com/dashpay/dips/blob/master/dip-0003.md) activation
+| 2 | 70214 | 0.14.0 | Enabled by [DIP8](https://github.com/dashpay/dips/blob/master/dip-0008.md) activation
+| 3 | 70230 | 20.0.0 | Enabled by [DIP29](https://github.com/dashpay/dips/blob/master/dip-0029.md) activation
 
 The following annotated hexdump shows a CbTx transaction (v3).
 

--- a/docs/reference/transactions-special-transactions.md
+++ b/docs/reference/transactions-special-transactions.md
@@ -689,8 +689,9 @@ The special transaction type used for CbTx Transactions is 5 and the extra paylo
 | 4 | height | uint32_t | Height of the block
 | 32 | merkleRootMNList | uint256 | Merkle root of the masternode list
 | 32 | merkleRootQuorums | uint256 | *Added by CbTx version 2 in v0.14.0*<br><br>Merkle root of currently active LLMQs
-| 4 | bestCLHeightDiff | uint32_t | ***Added by CbTx version 3 in v20.0.0***<br><br>Number of blocks between the current block and the last known block with a ChainLock
+| 4 | bestCLHeightDiff | compactSize uint | ***Added by CbTx version 3 in v20.0.0***<br><br>Number of blocks between the current block and the last known block with a ChainLock
 | 96 | bestCLSignature | CBLSSignature | ***Added by CbTx version 3 in Dash Core 20.0.0***<br>Best ChainLock signature known by the miner
+| 8 | creditPoolBalance | int64_t | ***Added by CbTx version 3 in Dash Core v20.0.0***<br>Balance in the Platform credit pool
 
 Version History
 
@@ -747,14 +748,16 @@ Coinbase Transaction Payload
 | ebb785522e0736257fd1655feb0f5a3f
 | 4c978e216dec3a07bc4554fe9d14e39b ......... Active LLMQ merkle root
 |
-| 00a269a7 ................................. Best ChainLock height diff
+| 00 ....................................... Best ChainLock height diff
 |
-| 696d8284e4a4f005bcbfc840b53e3145
-| 23864f726e183fdef5c9ed6319eb98ac
-| 2f398e45859ad4f28cf8ff5dab12ec5f
-| 4d315a1821b622c983fa387347607dce
-| e338c813f78bcacd4cbf756a40bf61bb
-| 5e9a2e5b508a5a51f3d7d069f0c8599f ......... ChainLock BLS signature
+| a269a7696d8284e4a4f005bcbfc840b5
+| 3e314523864f726e183fdef5c9ed6319
+| eb98ac2f398e45859ad4f28cf8ff5dab
+| 12ec5f4d315a1821b622c983fa387347
+| 607dcee338c813f78bcacd4cbf756a40
+| bf61bb5e9a2e5b508a5a51f3d7d069f0 ......... ChainLock BLS signature
+|
+| c8599f8c01000000 ......................... Credit pool balance (66.54220744 DASH)
 ```
 
 ### Example CbTx

--- a/docs/reference/transactions-special-transactions.md
+++ b/docs/reference/transactions-special-transactions.md
@@ -689,7 +689,7 @@ The special transaction type used for CbTx Transactions is 5 and the extra paylo
 | 4 | height | uint32_t | Height of the block
 | 32 | merkleRootMNList | uint256 | Merkle root of the masternode list
 | 32 | merkleRootQuorums | uint256 | *Added by CbTx version 2 in v0.14.0*<br><br>Merkle root of currently active LLMQs
-| 4 | bestCLHeightDiff | compactSize uint | ***Added by CbTx version 3 in v20.0.0***<br><br>Number of blocks between the current block and the last known block with a ChainLock
+| 1-9 | bestCLHeightDiff | compactSize uint | ***Added by CbTx version 3 in v20.0.0***<br><br>Number of blocks between the current block and the last known block with a ChainLock
 | 96 | bestCLSignature | CBLSSignature | ***Added by CbTx version 3 in Dash Core 20.0.0***<br>Best ChainLock signature known by the miner
 | 8 | creditPoolBalance | int64_t | ***Added by CbTx version 3 in Dash Core v20.0.0***<br>Balance in the Platform credit pool
 


### PR DESCRIPTION
Update the CbTx docs based on [DIP29](https://github.com/dashpay/dips/blob/master/dip-0029.md) and asset lock additions

<!-- Replace -->
Preview build: https://dash-docs--78.org.readthedocs.build/projects/core/en/78/
<!-- Replace -->
