### PR TITLE
fix: bump to latest version of sphinx search

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Babel==2.12.1
 myst-parser==2.0.0
 pydata-sphinx-theme==0.14.4
-readthedocs-sphinx-search==0.3.1
+readthedocs-sphinx-search==0.3.2
 sphinx==7.2.6
 sphinx-copybutton==0.5.2
 sphinx-hoverxref==1.3.0


### PR DESCRIPTION
To address this vulnerability: https://github.com/readthedocs/readthedocs.org/security/advisories/GHSA-qhqx-5j25-rv48