### PR TITLE
docs(p2p): islock deprecation, 2

### DIFF
--- a/docs/api/remote-procedure-calls-blockchain.md
+++ b/docs/api/remote-procedure-calls-blockchain.md
@@ -1621,7 +1621,7 @@ Name | Type | Presence | Description
 → →<br>`spentby` | array | Required<br>(exactly 1) | _Added in Dash Core 0.17.0_<br>An array of unconfirmed transactions spending outputs from this transaction
 → → →<br>TXID | string | Optional (0 or more) | The TXIDs of any unconfirmed transactions spending from this transaction
 → →<br>`unbroadcast` | bool | Required<br>(exactly 1) | **Added in Dash Core 20.0.0**<br>True if this transaction  is currently unbroadcast (initial broadcast not yet acknowledged by any peers)
-→ →<br>`instantlock` | bool | Required<br>(exactly 1) | *Added in Dash Core 0.12.3*<br><br>Set to `true` for locked InstantSend transactions (masternode quorum has locked the transaction inputs via `islock` message). Set to `false` if the masternodes have not approved the InstantSend transaction
+→ →<br>`instantlock` | bool | Required<br>(exactly 1) | *Added in Dash Core 0.12.3*<br><br>Set to `true` for locked InstantSend transactions (masternode quorum has locked the transaction inputs via `isdlock` message). Set to `false` if the masternodes have not approved the InstantSend transaction
 
 *Examples from Dash Core 20.0.0*
 

--- a/docs/api/zmq.md
+++ b/docs/api/zmq.md
@@ -37,7 +37,7 @@ Currently, the following notifications are supported:
 | zmqpubrawchainlocksig | Raw [`block`](../reference/p2p-network-data-messages.md#block) with ChainLock signature ([`clsig`](../reference/p2p-network-instantsend-messages.md#clsig)) concatenated |
 | zmqpubrawtx | Raw transaction ([`tx`](../reference/transactions-raw-transaction-format.md))  |
 | zmqpubrawtxlock | Raw InstantSend transaction ([`tx`](../reference/transactions-raw-transaction-format.md))  |
-| zmqpubrawtxlocksig | Raw InstantSend transaction ([`tx`](../reference/transactions-raw-transaction-format.md)) with InstantSend lock signature ([`islock`](../reference/p2p-network-instantsend-messages.md#islock)) concatenated |
+| zmqpubrawtxlocksig | Raw InstantSend transaction ([`tx`](../reference/transactions-raw-transaction-format.md)) with InstantSend lock signature ([`isdlock`](../reference/p2p-network-instantsend-messages.md#isdlock)) concatenated |
 | zmqpubrawgovernancevote | Raw governance vote ([`govobjvote`](../reference/p2p-network-governance-messages.md#govobjvote)) |
 | zmqpubrawgovernanceobject | Raw governance object ([`govobject`](../reference/p2p-network-governance-messages.md#govobj)) |
 | zmqpubrawinstantsend<br>doublespend | Raw transaction ([`tx`](../reference/transactions-raw-transaction-format.md)) attempting to double-spend an InstantSend-locked input |
@@ -62,7 +62,7 @@ The option to set the PUB socket's outbound message [high water mark](https://ze
 | zmqpubrawchainlockhwm | Raw [`block`](../reference/p2p-network-data-messages.md#block) receiving a ChainLock high water mark |
 | zmqpubrawchainlocksighwm | Raw [`block`](../reference/p2p-network-data-messages.md#block) with ChainLock signature ([`clsig`](../reference/p2p-network-instantsend-messages.md#clsig)) concatenated high water mark |
 | zmqpubrawtxlockhwm | Raw InstantSend transaction ([`tx`](../reference/transactions-raw-transaction-format.md)) high water mark |
-| zmqpubrawtxlocksighwm | Raw InstantSend transaction ([`tx`](../reference/transactions-raw-transaction-format.md)) with InstantSend lock signature ([`islock`](../reference/p2p-network-instantsend-messages.md#islock)) concatenated high water mark |
+| zmqpubrawtxlocksighwm | Raw InstantSend transaction ([`tx`](../reference/transactions-raw-transaction-format.md)) with InstantSend lock signature ([`isdlock`](../reference/p2p-network-instantsend-messages.md#isdlock)) concatenated high water mark |
 | zmqpubrawgovernancevotehwm | Raw governance vote ([`govobjvote`](../reference/p2p-network-governance-messages.md#govobjvote)) high water mark |
 | zmqpubrawgovernanceobjecthwm | Raw governance object ([`govobject`](../reference/p2p-network-governance-messages.md#govobj)) high water mark |
 | zmqpubrawinstantsenddoublespendhwm | Raw transaction ([`tx`](../reference/transactions-raw-transaction-format.md)) attempting to double-spend an InstantSend-locked input high water mark |

--- a/docs/examples/receiving-zmq-notifications.md
+++ b/docs/examples/receiving-zmq-notifications.md
@@ -147,7 +147,7 @@ The following response demonstrates the notification provided by Dash Core when 
   1. The TXID of the transaction is received (`HASHTX`) - at this point the transaction is not locked
   2. The TXID of a locked transaction is received (`HASHTXLOCK`). Since this is the same value as the `HASHTX` already received, we know that the transaction has now received an InstantSend lock.
   3. The raw transaction (`RAWTXLOCK`) (this could be decoded using the [`decoderawtransaction` RPC](../api/remote-procedure-calls-raw-transactions.md#decoderawtransaction) for example)
-  4. A combination of the raw transaction and the InstantSend [lock signature](../reference/p2p-network-instantsend-messages.md#islock) (`RAWTXLOCKSIG`)
+  4. A combination of the raw transaction and the InstantSend [lock signature](../reference/p2p-network-instantsend-messages.md#isdlock) (`RAWTXLOCKSIG`)
 
 ```
 Received HASHTX containing:

--- a/docs/guide/dash-features-instantsend.md
+++ b/docs/guide/dash-features-instantsend.md
@@ -51,6 +51,6 @@ A [miner](../resources/glossary.md#miner) may still include any transaction, but
 | **LLMQ Results**             |   |                         | Quorum results broadcast to the network |
 |                             | ← | [`inv` message](../reference/p2p-network-data-messages.md#inv) (islock or isdlock)  | Quorum responds with lock inventory
 | [`getdata` message](../reference/p2p-network-data-messages.md#getdata) (islock or isdlock)  | → |                         | Client requests lock message
-|                             | ← | [`islock` message](../reference/p2p-network-instantsend-messages.md#islock) or [`isdlock` message](../reference/p2p-network-instantsend-messages.md#isdlock)        | Quorum responds with lock message
+|                             | ← | [`isdlock` message](../reference/p2p-network-instantsend-messages.md#isdlock)        | Quorum responds with lock message
 
 Once a transaction lock is approved, the `instantlock` field of various RPCs is set to `true` (e.g. the [`getmempoolentry` RPC](../api/remote-procedure-calls-blockchain.md#getmempoolentry)).

--- a/docs/guide/dash-features-instantsend.md
+++ b/docs/guide/dash-features-instantsend.md
@@ -7,6 +7,8 @@
 
 # InstantSend
 
+## Overview
+
 Dash Core's [InstantSend](../resources/glossary.md#instantsend) feature provides a way to lock transaction [inputs](../resources/glossary.md#input) and enable secure, instantaneous [transactions](../resources/glossary.md#transaction). The [network](../resources/glossary.md#network) automatically attempts to upgrade any qualifying transaction to InstantSend without a need for the sending [wallet](../resources/glossary.md#wallet) to explicitly request it.
 
 * To qualify for InstantSend, each transaction input must meet at least one of the following criteria:
@@ -19,11 +21,11 @@ Dash Core's [InstantSend](../resources/glossary.md#instantsend) feature provides
 | Mainnet | 6 Blocks (normal transactions)<br>**100 Blocks (mining/masternode rewards)** |
 | Testnet / Regtest / Devnet | 2 Blocks |
 
-> 📘 Transition to Deterministic InstantSend lock
->
-> Protocol version 70220 implements [DIP22](https://github.com/dashpay/dips/blob/master/dip-0022.md) which adds the `isdlock` message as a replacement for the `islock` message. Once the transition is complete, the `islock` message will be deprecated.
+The introduction of the [Long-Living Masternode Quorum](../resources/glossary.md#long-living-masternode-quorum) feature in Dash Core 0.14 provided a foundation to scale InstantSend. The transaction input locking process (and resulting network traffic) now occurs only within the quorum. This minimized network congestion since only the [`isdlock` message](../reference/p2p-network-instantsend-messages.md#isdlock) produced by the locking process is relayed to the entire Dash network. The lock message contains all the information necessary to verify a successful transaction lock.
 
-The introduction of the [Long-Living Masternode Quorum](../resources/glossary.md#long-living-masternode-quorum) feature in Dash Core 0.14 provided a foundation to scale InstantSend. The transaction input locking process (and resulting network traffic) now occurs only within the quorum. This minimizes network congestion since only the [`islock` message](../reference/p2p-network-instantsend-messages.md#islock) or [`isdlock` message](../reference/p2p-network-instantsend-messages.md#isdlock) produced by the locking process is relayed to the entire Dash network. This message contains all the information necessary to verify a successful transaction lock.
+## Deterministic InstantSend
+
+Protocol version 70220 implemented deterministic InstantSend (see [DIP22](https://github.com/dashpay/dips/blob/master/dip-0022.md)) which added the `isdlock` message as a replacement for the `islock` message. The `islock` message was deprecated and fully removed in protocol version 70231.
 
 ## Management via Spork
 
@@ -47,10 +49,10 @@ A [miner](../resources/glossary.md#miner) may still include any transaction, but
 | [`tx` message](../reference/p2p-network-data-messages.md#tx)                | → |                         | Client sends InstantSend transaction
 | **LLMQ Signing Sessions**   |   |                         | Quorums internally process locking |
 |                             |   |                         | Quorum(s) responsible for the transaction's inputs lock the inputs via LLMQ signing sessions
-|                             |   |                         | Once all inputs are locked, the quorum responsible for the overall transaction creates the transaction lock (`islock` or `isdlock`) via an LLMQ signing session
+|                             |   |                         | Once all inputs are locked, the quorum responsible for the overall transaction creates the transaction lock (`isdlock`) via an LLMQ signing session
 | **LLMQ Results**             |   |                         | Quorum results broadcast to the network |
-|                             | ← | [`inv` message](../reference/p2p-network-data-messages.md#inv) (islock or isdlock)  | Quorum responds with lock inventory
-| [`getdata` message](../reference/p2p-network-data-messages.md#getdata) (islock or isdlock)  | → |                         | Client requests lock message
+|                             | ← | [`inv` message](../reference/p2p-network-data-messages.md#inv) (isdlock)  | Quorum responds with lock inventory
+| [`getdata` message](../reference/p2p-network-data-messages.md#getdata) (isdlock)  | → |                         | Client requests lock message
 |                             | ← | [`isdlock` message](../reference/p2p-network-instantsend-messages.md#isdlock)        | Quorum responds with lock message
 
 Once a transaction lock is approved, the `instantlock` field of various RPCs is set to `true` (e.g. the [`getmempoolentry` RPC](../api/remote-procedure-calls-blockchain.md#getmempoolentry)).

--- a/docs/guide/p2p-network-misbehaving-nodes.md
+++ b/docs/guide/p2p-network-misbehaving-nodes.md
@@ -47,7 +47,7 @@ Furthermore, a few additional changes are introduced to how discouraged addresse
 | Net | Bloom Filter Size | **100** | Maximum script element size (520) exceeded (`filterload` message or [`filteradd` message](../reference/p2p-network-control-messages.md#filteradd))
 | Net | MN List Diff | 1 | Failed to get masternode list diff (`getmnlistd` message)
 | Net | Unrequested MN List Diff | **100** | Peer provided an unrequested masternode list diff (`mnlistdiff` message)
-| InstantSend | Invalid Lock Message | **100** | Invalid TXID or inputs in lock message (`islock` message)
+| InstantSend | Invalid Lock Message | **100** | Invalid TXID or inputs in lock message (`isdlock` message)
 | InstantSend | Verify Error | 20 | Peer relayed a message that failed to verify
 | LLMQ ChainLock | Invalid | 10 | Invalid ChainLock message (`clsig` message)
 | LLMQ Commitment | Null QcTx | **100** | Peer relayed a block with a null commitment

--- a/docs/reference/p2p-network-data-messages.md
+++ b/docs/reference/p2p-network-data-messages.md
@@ -560,7 +560,7 @@ Sending the [`mempool` message](../reference/p2p-network-data-messages.md#mempoo
 
 > 📘 InstantSend and ChainLock Synchronization
 >
-> Dash Core 0.15.0 expanded the mempool message to include syncing of [InstantSend Lock](../reference/p2p-network-instantsend-messages.md#islock) inventories. Additionally, nodes now attempt to sync their mempool with peers at startup by default (limited to peers using protocol version 70216 or higher). This allows nodes to more quickly detect any double-spend attempts as well as show InstantSend lock status correctly for transactions received while offline.
+> Dash Core 0.15.0 expanded the mempool message to include syncing of [InstantSend Lock](../reference/p2p-network-deprecated-messages.md#islock) inventories. Additionally, nodes now attempt to sync their mempool with peers at startup by default (limited to peers using protocol version 70216 or higher). This allows nodes to more quickly detect any double-spend attempts as well as show InstantSend lock status correctly for transactions received while offline.
 >
 >Dash Core 0.17.0 expanded the mempool message to include syncing of [ChainLock](../reference/p2p-network-instantsend-messages.md#clsig) inventories. This allows nodes to more quickly show ChainLock status correctly after being offline.
 
@@ -574,7 +574,7 @@ There is no payload in a [`mempool` message](../reference/p2p-network-data-messa
 
 _Added in protocol version 70001 as described by BIP37._
 
-The [`merkleblock` message](../reference/p2p-network-data-messages.md#merkleblock) is a reply to a [`getdata` message](../reference/p2p-network-data-messages.md#getdata) which requested a [block](../resources/glossary.md#block) using the inventory type `MSG_MERKLEBLOCK`.  It is only part of the reply: if any matching transactions are found, they will be sent separately as [`tx` messages](../reference/p2p-network-data-messages.md#tx). As of Dash Core 0.17.0 [`islock` messages](../reference/p2p-network-instantsend-messages.md#islock) for matching transactions are sent if present.
+The [`merkleblock` message](../reference/p2p-network-data-messages.md#merkleblock) is a reply to a [`getdata` message](../reference/p2p-network-data-messages.md#getdata) which requested a [block](../resources/glossary.md#block) using the inventory type `MSG_MERKLEBLOCK`.  It is only part of the reply: if any matching transactions are found, they will be sent separately as [`tx` messages](../reference/p2p-network-data-messages.md#tx). As of Dash Core 18.0.0 [`isdlock` messages](../reference/p2p-network-instantsend-messages.md#isdlock) for matching transactions are sent if present.
 
 > 🚧
 >

--- a/docs/reference/p2p-network-data-messages.md
+++ b/docs/reference/p2p-network-data-messages.md
@@ -578,7 +578,7 @@ The [`merkleblock` message](../reference/p2p-network-data-messages.md#merklebloc
 
 > 🚧
 >
-> Note: `islock` messages are currently dropped once a ChainLock is present so in most cases they will not actually be provided in response to a merkleblock request. Future updates may modify this behavior.
+> Note: `isdlock` messages are currently dropped once a ChainLock is present so in most cases they will not actually be provided in response to a merkleblock request. Future updates may modify this behavior.
 
 If a filter has been previously set with the [`filterload` message](../reference/p2p-network-control-messages.md#filterload), the [`merkleblock` message](../reference/p2p-network-data-messages.md#merkleblock) will contain the [TXIDs](../resources/glossary.md#transaction-identifiers) of any transactions in the requested block that matched the filter, as well as any parts of the block's [merkle tree](../resources/glossary.md#merkle-tree) necessary to connect those transactions to the block header's [merkle root](../resources/glossary.md#merkle-root). The message also contains a complete copy of the [block header](../resources/glossary.md#block-header) to allow the client to hash it and confirm its [proof of work](../resources/glossary.md#proof-of-work).
 

--- a/docs/reference/p2p-network-deprecated-messages.md
+++ b/docs/reference/p2p-network-deprecated-messages.md
@@ -6,9 +6,8 @@
 
 ## Alert
 
->❗️
->
-> Deprecated since 0.15.0
+:::{deprecated} 0.15.0
+:::
 
 *Added in protocol version 311.*
 *Removed by Bitcoin in protocol version 70013, but retained by Dash until 0.15.0.*
@@ -135,9 +134,8 @@ The `ix` message (transaction lock request) has the same structure as the [`tx` 
 
 ## reject
 
->❗️
->
-> Removed in 19.0.0
+:::{deprecated} 19.0.0
+:::
 
 *Added in protocol version 70002 as described by BIP61.*
 
@@ -209,9 +207,8 @@ The annotated hexdump below shows a [`reject` message](#reject). (The message he
 
 ## txlvote
 
->❗️
->
-> Deprecated since 0.15.0
+:::{deprecated} 0.15.0
+:::
 
 The `txlvote` message (transaction lock vote) is sent by masternodes to indicate approval of a transaction lock request `ix` message.
 

--- a/docs/reference/p2p-network-deprecated-messages.md
+++ b/docs/reference/p2p-network-deprecated-messages.md
@@ -85,11 +85,51 @@ c42c13810ffcae14995bb648340219e3
 
 **Alert key compromise:** Dash Core's source code defines a particular set of alert parameters that can be used to notify users that the alert signing key has been compromised and that they should upgrade to get a new alert public key. Once a signed alert containing those parameters has been received, no other alerts can cancel or override it.
 
+## islock
+
+:::{deprecated} 20.1.0
+Dash protocol version 70231 removed support for non-deterministic InstantSend. The [`isdlock` message](../reference/p2p-network-instantsend-messages.md#isdlock) with expanded features replaced this message.
+:::
+
+The [`islock` message](../reference/p2p-network-deprecated-messages.md#islock) is used to provide details of transactions that have been locked by LLMQ-based InstantSend. The message includes the details of all transaction [inputs](../resources/glossary.md#input) along with the transaction ID and the BLS [signature](../resources/glossary.md#signature) of the [LLMQ](../resources/glossary.md#long-living-masternode-quorum) that approved the transaction lock.
+
+| Bytes | Name | Data type | Description |
+| --- | --- | --- | --- |
+| 1-9 | inputsSize | compactSize uint | Number of inputs |
+| 36 * `inputsSize`| inputs | COutPoint | Outpoints used in the transaction |
+| 32 | txid | uint256 | TXID of the locked transaction |
+| 96 | sig | byte[] | LLMQ BLS Signature |
+
+The following annotated hexdump shows a [`islock` message](../reference/p2p-network-deprecated-messages.md#islock). (The message header has been omitted.)
+
+``` text
+02 ......................................... Number of inputs: 2
+
+Input 1
+| 05f24f65a9d98ff543ba61f7f0ce9448
+| 79632bf2517540a5bd8bde2fe8e94617 ......... Previous outpoint TXID
+| 00000000 ................................. Previous outpoint index: 0
+
+Input 2
+| 05f24f65a9d98ff543ba61f7f0ce9448
+| 79632bf2517540a5bd8bde2fe8e94617 ......... Previous outpoint TXID
+| 01000000 ................................. Previous outpoint index: 1
+
+e2e1c797576d8b13c83e929684b9aacd
+553c20a34e2d11e38bdcaaf8e1de1680 ........... TXID
+
+0f055c2064885d446f83d51b9bb09892
+7ea0375a0f6a3f3402abf158ece67e00
+81049b8a8f45d254b64574cef194ef31
+197e450fba1196d652f2e1421d3b80ae
+f429c10eabd4ab9289e9a8f80f6989b7
+a11e5e7930deccc3e11a931fc9524f06 ........... LLMQ BLS Signature (96 bytes)
+```
+
 ## ix
 
->❗️
->
-> Deprecated since 0.15.0
+:::{deprecated} 0.15.0
+:::
 
 The `ix` message (transaction lock request) has the same structure as the [`tx` message](../reference/p2p-network-data-messages.md#tx). The masternode network responds with `txlvote` messages if the transaction inputs can be locked.
 

--- a/docs/reference/p2p-network-instantsend-messages.md
+++ b/docs/reference/p2p-network-instantsend-messages.md
@@ -44,7 +44,7 @@ dcd5497d105932e609016dac075f02df
 >
 > *Added in protocol version 70220 of Dash Core*
 
-The [`isdlock` message](../reference/p2p-network-instantsend-messages.md#isdlock) is used to provide details of transactions that have been locked by InstantSend. The message includes all details present in the [`islock` message](#islock) along with additional version and cycle information introduced by [DIP22](https://github.com/dashpay/dips/blob/master/dip-0022.md).  This enables nodes to determine what quorum signed the message and validate the signature in the future after the quorum is no longer active. Additional details about the change are available in [DIP22 - Making InstantSend Deterministic using Quorum Cycles](https://github.com/dashpay/dips/blob/master/dip-0022.md).
+The [`isdlock` message](../reference/p2p-network-instantsend-messages.md#isdlock) is used to provide details of transactions that have been locked by InstantSend. The message includes all details present in the [`islock` message](../reference/p2p-network-deprecated-messages.md#islock) along with additional version and cycle information introduced by [DIP22](https://github.com/dashpay/dips/blob/master/dip-0022.md).  This enables nodes to determine what quorum signed the message and validate the signature in the future after the quorum is no longer active. Additional details about the change are available in [DIP22 - Making InstantSend Deterministic using Quorum Cycles](https://github.com/dashpay/dips/blob/master/dip-0022.md).
 
 | Bytes | Name | Data type | Description |
 | --- | --- | --- | --- |

--- a/docs/reference/p2p-network-instantsend-messages.md
+++ b/docs/reference/p2p-network-instantsend-messages.md
@@ -38,49 +38,6 @@ dcd5497d105932e609016dac075f02df
 005574710c3aabc2f8670959cf8bc9b5 ........... LLMQ BLS Signature
 ```
 
-## islock
-
-*Added in protocol version 70214 of Dash Core*
-
-> 🚧 Future deprecation
->
-> The [`isdlock` message](#isdlock) with expanded features will eventually replace this message. Protocol version 70220 maintains backwards compatibility for older clients.
-
-The [`islock` message](../reference/p2p-network-instantsend-messages.md#islock) is used to provide details of transactions that have been locked by LLMQ-based InstantSend. The message includes the details of all transaction [inputs](../resources/glossary.md#input) along with the transaction ID and the BLS [signature](../resources/glossary.md#signature) of the [LLMQ](../resources/glossary.md#long-living-masternode-quorum) that approved the transaction lock.
-
-| Bytes | Name | Data type | Description |
-| --- | --- | --- | --- |
-| 1-9 | inputsSize | compactSize uint | Number of inputs |
-| 36 * `inputsSize`| inputs | COutPoint | Outpoints used in the transaction |
-| 32 | txid | uint256 | TXID of the locked transaction |
-| 96 | sig | byte[] | LLMQ BLS Signature |
-
-The following annotated hexdump shows a [`islock` message](../reference/p2p-network-instantsend-messages.md#islock). (The message header has been omitted.)
-
-``` text
-02 ......................................... Number of inputs: 2
-
-Input 1
-| 05f24f65a9d98ff543ba61f7f0ce9448
-| 79632bf2517540a5bd8bde2fe8e94617 ......... Previous outpoint TXID
-| 00000000 ................................. Previous outpoint index: 0
-
-Input 2
-| 05f24f65a9d98ff543ba61f7f0ce9448
-| 79632bf2517540a5bd8bde2fe8e94617 ......... Previous outpoint TXID
-| 01000000 ................................. Previous outpoint index: 1
-
-e2e1c797576d8b13c83e929684b9aacd
-553c20a34e2d11e38bdcaaf8e1de1680 ........... TXID
-
-0f055c2064885d446f83d51b9bb09892
-7ea0375a0f6a3f3402abf158ece67e00
-81049b8a8f45d254b64574cef194ef31
-197e450fba1196d652f2e1421d3b80ae
-f429c10eabd4ab9289e9a8f80f6989b7
-a11e5e7930deccc3e11a931fc9524f06 ........... LLMQ BLS Signature (96 bytes)
-```
-
 ## isdlock
 
 > 📘

--- a/docs/reference/p2p-network-quorum-messages.md
+++ b/docs/reference/p2p-network-quorum-messages.md
@@ -645,7 +645,7 @@ More information can be found in the [Recovered threshold signatures section of 
 
 The following annotated hexdump shows a [`qsigrec` message](../reference/p2p-network-quorum-messages.md#qsigrec). (The message header has been omitted.)
 
-**Note:** The following [`qsigrec` message](../reference/p2p-network-quorum-messages.md#qsigrec) corresponds to the example [`islock` message](../reference/p2p-network-instantsend-messages.md#islock) hexdump. The message hash below corresponds to the `islock` TXID field and the BLS signature matches the BLS signature of the `islock` example.
+**Note:** The following [`qsigrec` message](../reference/p2p-network-quorum-messages.md#qsigrec) corresponds to the example [`islock` message](../reference/p2p-network-deprecated-messages.md#islock) hexdump. The message hash below corresponds to the `islock` TXID field and the BLS signature matches the BLS signature of the `islock` example.
 
 ``` text
 01 ......................................... LLMQ Type: 1 (LLMQ_50_60)

--- a/docs/reference/p2p-network-quorum-messages.md
+++ b/docs/reference/p2p-network-quorum-messages.md
@@ -611,7 +611,7 @@ Signature share request 2
 
 *Added in protocol version 70214 of Dash Core*
 
-The [`qsendrecsigs` message](../reference/p2p-network-quorum-messages.md#qsendrecsigs) is used to notify a [peer](../resources/glossary.md#peer) to send plain [LLMQ](../resources/glossary.md#long-living-masternode-quorum) recovered signatures (inventory type `MSG_QUORUM_RECOVERED_SIG`). Otherwise the peer would only announce/send the higher level messages produced when a recovered signature is found (e.g. InstantSend [`islock` messages](../reference/p2p-network-instantsend-messages.md#islock) or ChainLock [`clsig` messages](../reference/p2p-network-instantsend-messages.md#clsig)).
+The [`qsendrecsigs` message](../reference/p2p-network-quorum-messages.md#qsendrecsigs) is used to notify a [peer](../resources/glossary.md#peer) to send plain [LLMQ](../resources/glossary.md#long-living-masternode-quorum) recovered signatures (inventory type `MSG_QUORUM_RECOVERED_SIG`). Otherwise the peer would only announce/send the higher level messages produced when a recovered signature is found (e.g. InstantSend [`isdlock` messages](../reference/p2p-network-instantsend-messages.md#isdlock) or ChainLock [`clsig` messages](../reference/p2p-network-instantsend-messages.md#clsig)).
 
 > 📘
 >


### PR DESCRIPTION
Updates InstantSend related docs based on islock deprecation in https://github.com/dashpay/dash/pull/5553.

<!-- Replace -->
Preview build: https://dash-docs--102.org.readthedocs.build/projects/core/en/102/docs/reference/p2p-network-deprecated-messages.html#islock
<!-- Replace -->
