### PR TITLE
docs(rpc): v22 rpc updates, 2

### DIFF
--- a/docs/api/remote-procedure-call-quick-reference.md
+++ b/docs/api/remote-procedure-call-quick-reference.md
@@ -103,7 +103,7 @@ These RPCs are all Dash-specific and not found in Bitcoin Core
 
 ## [Network RPCs](../api/remote-procedure-calls-network.md)
 
-* [AddNode](../api/remote-procedure-calls-network.md#addnode): attempts to add or remove a node from the addnode list, or to try a connection to a node once.
+* [AddNode](../api/remote-procedure-calls-network.md#addnode): attempts to add or remove a node from the addnode list, or to try a connection to a node once. **Updated in Dash Core 22.0.0**
 * [AddPeerAddress](../api/remote-procedure-calls-network.md#addpeeraddress): adds the address of a potential peer to the address manager. **Updated in Dash Core 22.0.0**
 * [ClearBanned](../api/remote-procedure-calls-network.md#clearbanned): clears list of banned nodes.
 * [ClearDiscouraged](../api/remote-procedure-calls-network.md#cleardiscouraged): clears all discouraged nodes. **_New in Dash Core 19.0.0_**

--- a/docs/api/remote-procedure-call-quick-reference.md
+++ b/docs/api/remote-procedure-call-quick-reference.md
@@ -203,9 +203,9 @@ These RPCs are all Dash-specific and not found in Bitcoin Core
 * [RemovePrunedFunds](../api/remote-procedure-calls-wallet.md#removeprunedfunds): deletes the specified transaction from the wallet. Meant for use with pruned wallets and as a companion to importprunedfunds. _New in Dash Core 0.12.3_
 * [RescanBlockChain](../api/remote-procedure-calls-wallet.md#rescanblockchain): rescans the local blockchain for wallet related transactions. _New in Dash Core 0.16.0_
 * [ScanTxOutset](../api/remote-procedure-calls-wallet.md#scantxoutset): scans the unspent transaction output set for entries that match certain output descriptors. _New in Dash Core 18.0.0_
-* [Send](../api/remote-procedure-calls-wallet.md#send): sends a transaction with specified outputs. **New in Dash Core 21.0.0**
-* [SendMany](../api/remote-procedure-calls-wallet.md#sendmany): creates and broadcasts a transaction which sends outputs to multiple addresses. **Updated in Dash Core 21.0.0**
-* [SendToAddress](../api/remote-procedure-calls-wallet.md#sendtoaddress): spends an amount to a given address. **Updated in Dash Core 21.0.0**
+* [Send](../api/remote-procedure-calls-wallet.md#send): sends a transaction with specified outputs. **Updated in Dash Core 22.0.0**
+* [SendMany](../api/remote-procedure-calls-wallet.md#sendmany): creates and broadcasts a transaction which sends outputs to multiple addresses. **Updated in Dash Core 22.0.0**
+* [SendToAddress](../api/remote-procedure-calls-wallet.md#sendtoaddress): spends an amount to a given address. **Updated in Dash Core 22.0.0**
 * [SetHDSeed](../api/remote-procedure-calls-wallet.md#sethdseed): sets or generates a new HD wallet seed **New in Dash Core 21.0.0**
 * [SetLabel](../api/remote-procedure-calls-wallet.md#setlabel): sets the label associated with the given address.
 * [SetCoinJoinAmount](../api/remote-procedure-calls-wallet.md#setcoinjoinamount): sets the amount of DASH to be processed _New in Dash Core 0.13.0_

--- a/docs/api/remote-procedure-call-quick-reference.md
+++ b/docs/api/remote-procedure-call-quick-reference.md
@@ -22,8 +22,8 @@ These RPCs are all Dash-specific and not found in Bitcoin Core
 * [GetBestBlockHash](../api/remote-procedure-calls-blockchain.md#getbestblockhash): returns the header hash of the most recent block on the best block chain.
 * [DumpTxOutset](../api/remote-procedure-calls-blockchain.md#dumptxoutset): Write the serialized UTXO set to disk. _New in Dash Core 18.1.0_
 * [GetBestChainLock](../api/remote-procedure-calls-blockchain.md#getbestchainlock): returns the block hash of the best chainlock. _New in Dash Core 0.15.0_
-* [GetBlock](../api/remote-procedure-calls-blockchain.md#getblock): gets a block with a particular header hash from the local block database either as a JSON object or as a serialized block. **Updated in Dash Core 21.0.0**
-* [GetBlockChainInfo](../api/remote-procedure-calls-blockchain.md#getblockchaininfo): provides information about the current state of the block chain. **Updated in Dash Core 21.0.0**
+* [GetBlock](../api/remote-procedure-calls-blockchain.md#getblock): gets a block with a particular header hash from the local block database either as a JSON object or as a serialized block. **_Updated in Dash Core 21.0.0_**
+* [GetBlockChainInfo](../api/remote-procedure-calls-blockchain.md#getblockchaininfo): provides information about the current state of the block chain. **_Updated in Dash Core 21.0.0_**
 * [GetBlockCount](../api/remote-procedure-calls-blockchain.md#getblockcount): returns the number of blocks in the local best block chain.
 * [GetBlockFilter](../api/remote-procedure-calls-blockchain.md#getblockfilter): retrieves a [BIP157](https://github.com/bitcoin/bips/blob/master/bip-0157.mediawiki) content filter for a particular block. _New in Dash Core 18.0.0_
 * [GetBlockFromPeer](../api/remote-procedure-calls-blockchain.md#getblockfrompeer): attempts to fetch a specific block from a given peer. **Updated in Dash Core 22.0.0**
@@ -35,15 +35,15 @@ These RPCs are all Dash-specific and not found in Bitcoin Core
 * [GetChainTips](../api/remote-procedure-calls-blockchain.md#getchaintips): returns information about the highest-height block (tip) of each local block chain. _Updated in Dash Core 0.12.3_
 * [GetChainTxStats](../api/remote-procedure-calls-blockchain.md#getchaintxstats): compute statistics about the total number and rate of transactions in the chain. _Updated in Dash Core 18.0.0_
 * [GetDifficulty](../api/remote-procedure-calls-blockchain.md#getdifficulty): returns the proof-of-work difficulty as a multiple of the minimum difficulty.
-* [GetMemPoolAncestors](../api/remote-procedure-calls-blockchain.md#getmempoolancestors): returns all in-mempool ancestors for a transaction in the mempool. **Updated in Dash Core 20.0.0**
-* [GetMemPoolDescendants](../api/remote-procedure-calls-blockchain.md#getmempooldescendants): returns all in-mempool descendants for a transaction in the mempool. **Updated in Dash Core 20.0.0**
-* [GetMemPoolEntry](../api/remote-procedure-calls-blockchain.md#getmempoolentry): returns mempool data for given transaction (must be in mempool). **Updated in Dash Core 20.0.0**
-* [GetMemPoolInfo](../api/remote-procedure-calls-blockchain.md#getmempoolinfo): returns information about the node's current transaction memory pool. **Updated in Dash Core 20.1.0**
+* [GetMemPoolAncestors](../api/remote-procedure-calls-blockchain.md#getmempoolancestors): returns all in-mempool ancestors for a transaction in the mempool. _Updated in Dash Core 20.0.0_
+* [GetMemPoolDescendants](../api/remote-procedure-calls-blockchain.md#getmempooldescendants): returns all in-mempool descendants for a transaction in the mempool. _Updated in Dash Core 20.0.0_
+* [GetMemPoolEntry](../api/remote-procedure-calls-blockchain.md#getmempoolentry): returns mempool data for given transaction (must be in mempool). _Updated in Dash Core 20.0.0_
+* [GetMemPoolInfo](../api/remote-procedure-calls-blockchain.md#getmempoolinfo): returns information about the node's current transaction memory pool. _Updated in Dash Core 20.1.0_
 * [GetRawMemPool](../api/remote-procedure-calls-blockchain.md#getrawmempool): returns all transaction identifiers (TXIDs) in the memory pool as a JSON array, or detailed information about each transaction in the memory pool as a JSON object. **Updated in Dash Core 22.0.0**
 * [GetMerkleBlocks](../api/remote-procedure-calls-blockchain.md#getmerkleblocks): returns an array of hex-encoded merkleblocks for <count> blocks starting from <hash> which match <filter>. _New in Dash Core 0.15.0_
 * [GetSpecialTxes](../api/remote-procedure-calls-blockchain.md#getspecialtxes): returns an array of special transactions found in the specified block _New in Dash Core 0.13.1_
 * [GetSpentInfo](../api/remote-procedure-calls-blockchain.md#getspentinfo): returns the txid and index where an output is spent (requires `spentindex` to be enabled). New in Dash Core 0.12.1
-* [GetTxOut](../api/remote-procedure-calls-blockchain.md#gettxout): returns details about an unspent transaction output (UTXO). **Updated in Dash Core 21.0.0**
+* [GetTxOut](../api/remote-procedure-calls-blockchain.md#gettxout): returns details about an unspent transaction output (UTXO). **_Updated in Dash Core 21.0.0_**
 * [GetTxOutProof](../api/remote-procedure-calls-blockchain.md#gettxoutproof): returns a hex-encoded proof that one or more specified transactions were included in a block.
 * [GetTxOutSetInfo](../api/remote-procedure-calls-blockchain.md#gettxoutsetinfo): returns statistics about the confirmed unspent transaction output (UTXO) set. Note that this call may take some time and that it only counts outputs from confirmed transactions---it does not count outputs from the memory pool. _Updated in Dash Core 18.1.0_
 * [PreciousBlock](../api/remote-procedure-calls-blockchain.md#preciousblock): treats a block as if it were received before others with the same work. _New in Dash Core 0.12.3_
@@ -67,11 +67,11 @@ These RPCs are all Dash-specific and not found in Bitcoin Core
 * [CoinJoin](../api/remote-procedure-calls-dash.md#coinjoin): controls the CoinJoin process. _Updated in Dash Core 0.12.3_
 * [CoinJoinSalt](../api/remote-procedure-calls-dash.md#coinjoinsalt): controls the CoinJoin salt used in the process. It allows you to generate, retrieve, or set the salt. **Added in Dash Core 22.0.0**
 * [GetCoinJoinInfo](../api/remote-procedure-calls-dash.md#getcoinjoininfo): returns an object containing an information about CoinJoin settings and state. **Updated in Dash Core 22.0.0**
-* [GetGovernanceInfo](../api/remote-procedure-calls-dash.md#getgovernanceinfo): returns an object containing governance parameters. **Updated in Dash Core 20.0.0**
+* [GetGovernanceInfo](../api/remote-procedure-calls-dash.md#getgovernanceinfo): returns an object containing governance parameters. _Updated in Dash Core 20.0.0_
 * [GetSuperblockBudget](../api/remote-procedure-calls-dash.md#getsuperblockbudget): returns the absolute maximum sum of superblock payments allowed.
-* [GObject](../api/remote-procedure-calls-dash.md#gobject): provides a set of commands for managing governance objects and displaying information about them. **Updated in Dash Core 20.0.0**
+* [GObject](../api/remote-procedure-calls-dash.md#gobject): provides a set of commands for managing governance objects and displaying information about them. _Updated in Dash Core 20.0.0_
 * [Masternode](../api/remote-procedure-calls-dash.md#masternode): provides a set of commands for managing masternodes and displaying information about them. **Updated in Dash Core 22.0.0**
-* [MasternodeList](../api/remote-procedure-calls-dash.md#masternodelist): returns a list of masternodes in different modes. **Updated in Dash Core 20.0.0**
+* [MasternodeList](../api/remote-procedure-calls-dash.md#masternodelist): returns a list of masternodes in different modes. _Updated in Dash Core 20.0.0_
 * [MnSync](../api/remote-procedure-calls-dash.md#mnsync): returns the sync status, updates to the next step or resets it entirely. _Updated in Dash Core 0.14.0_
 * [Spork](../api/remote-procedure-calls-dash.md#spork): shows information about the current state of sporks. _Updated in Dash Core 18.1.0_
 * [SporkUpdate](../api/remote-procedure-calls-dash.md#sporkupdate): updates the value of the provided spork. _New in Dash Core 18.1.0_
@@ -79,10 +79,10 @@ These RPCs are all Dash-specific and not found in Bitcoin Core
 
 ## [Evolution RPCs](../api/remote-procedure-calls-evo.md)
 
-* [BLS](../api/remote-procedure-calls-evo.md#bls): provides a set of commands to execute BLS-related actions. **_Updated in Dash Core 19.0.0_**
-* [ProTx](../api/remote-procedure-calls-evo.md#protx): provides a set of commands to execute ProTx related actions. **Updated in Dash Core 20.1.0**
+* [BLS](../api/remote-procedure-calls-evo.md#bls): provides a set of commands to execute BLS-related actions. _Updated in Dash Core 19.0.0_
+* [ProTx](../api/remote-procedure-calls-evo.md#protx): provides a set of commands to execute ProTx related actions. _Updated in Dash Core 20.1.0_
 * [Quorum](../api/remote-procedure-calls-evo.md#quorum): provides a set of commands for quorums (LLMQs). **Updated in Dash Core 22.0.0**
-* [SubmitChainLock](../api/remote-procedure-calls-evo.md#submitchainlock): allows the submission of a ChainLock signature. **New in Dash Core 20.1.0**
+* [SubmitChainLock](../api/remote-procedure-calls-evo.md#submitchainlock): allows the submission of a ChainLock signature. _New in Dash Core 20.1.0_
 * [VerifyChainLock](../api/remote-procedure-calls-evo.md#verifychainlock): tests if a quorum signature is valid for a ChainLock. _New in Dash Core 0.17.0_
 * [VerifyISLock](../api/remote-procedure-calls-evo.md#verifyislock): tests if a quorum signature is valid for an InstantSend lock. _New in Dash Core 0.17.0_
 
@@ -94,7 +94,7 @@ These RPCs are all Dash-specific and not found in Bitcoin Core
 
 ## [Mining RPCs](../api/remote-procedure-calls-mining.md)
 
-* [GetBlockTemplate](../api/remote-procedure-calls-mining.md#getblocktemplate): gets a block template or proposal for use with mining software. **Updated in Dash Core 20.0.0**
+* [GetBlockTemplate](../api/remote-procedure-calls-mining.md#getblocktemplate): gets a block template or proposal for use with mining software. _Updated in Dash Core 20.0.0_
 * [GetMiningInfo](../api/remote-procedure-calls-mining.md#getmininginfo): returns various mining-related information. _Updated in Dash Core 18.0.0_
 * [GetNetworkHashPS](../api/remote-procedure-calls-mining.md#getnetworkhashps): returns the estimated network hashes per second based on the last n blocks.
 * [PrioritiseTransaction](../api/remote-procedure-calls-mining.md#prioritisetransaction): adds virtual priority or fee to a transaction, allowing it to be accepted into blocks mined by this node (or miners which use this node) with a lower priority or fee. (It can also remove virtual priority or fee, requiring the transaction have a higher priority or fee to be accepted into a locally-mined block.) _Updated in Dash Core 0.14.0_
@@ -106,15 +106,15 @@ These RPCs are all Dash-specific and not found in Bitcoin Core
 * [AddNode](../api/remote-procedure-calls-network.md#addnode): attempts to add or remove a node from the addnode list, or to try a connection to a node once. **Updated in Dash Core 22.0.0**
 * [AddPeerAddress](../api/remote-procedure-calls-network.md#addpeeraddress): adds the address of a potential peer to the address manager. **Updated in Dash Core 22.0.0**
 * [ClearBanned](../api/remote-procedure-calls-network.md#clearbanned): clears list of banned nodes.
-* [ClearDiscouraged](../api/remote-procedure-calls-network.md#cleardiscouraged): clears all discouraged nodes. **_New in Dash Core 19.0.0_**
+* [ClearDiscouraged](../api/remote-procedure-calls-network.md#cleardiscouraged): clears all discouraged nodes. _New in Dash Core 19.0.0_
 * [DisconnectNode](../api/remote-procedure-calls-network.md#disconnectnode): immediately disconnects from a specified node. _Updated in Dash Core 0.15.0_
-* [GetAddedNodeInfo](../api/remote-procedure-calls-network.md#getaddednodeinfo): returns information about the given added node, or all added nodes (except onetry nodes). Only nodes which have been manually added using the [`addnode` RPC](../api/remote-procedure-calls-network.md#addnode) will have their information displayed. **Updated in Dash Core 21.0.0**
+* [GetAddedNodeInfo](../api/remote-procedure-calls-network.md#getaddednodeinfo): returns information about the given added node, or all added nodes (except onetry nodes). Only nodes which have been manually added using the [`addnode` RPC](../api/remote-procedure-calls-network.md#addnode) will have their information displayed. **_Updated in Dash Core 21.0.0_**
 * [GetConnectionCount](../api/remote-procedure-calls-network.md#getconnectioncount): returns the number of connections to other nodes.
 * [GetNetTotals](../api/remote-procedure-calls-network.md#getnettotals): returns information about network traffic, including bytes in, bytes out, and the current time.
-* [GetNetworkInfo](../api/remote-procedure-calls-network.md#getnetworkinfo): returns information about the node's connection to the network. **Updated in Dash Core 21.0.0**
-* [GetNodeAddresses](../api/remote-procedure-calls-network.md#getnodeaddresses): returns the known addresses which can potentially be used to find new nodes in the network. **Updated in Dash Core 21.0.0**
+* [GetNetworkInfo](../api/remote-procedure-calls-network.md#getnetworkinfo): returns information about the node's connection to the network. **_Updated in Dash Core 21.0.0_**
+* [GetNodeAddresses](../api/remote-procedure-calls-network.md#getnodeaddresses): returns the known addresses which can potentially be used to find new nodes in the network. **_Updated in Dash Core 21.0.0_**
 * [GetPeerInfo](../api/remote-procedure-calls-network.md#getpeerinfo): returns data about each connected network node. **Updated in Dash Core 22.0.0**
-* [ListBanned](../api/remote-procedure-calls-network.md#listbanned): lists all banned IPs/Subnets. **Updated in Dash Core 21.0.0**
+* [ListBanned](../api/remote-procedure-calls-network.md#listbanned): lists all banned IPs/Subnets. **_Updated in Dash Core 21.0.0_**
 * [Ping](../api/remote-procedure-calls-network.md#ping): sends a P2P ping message to all connected nodes to measure ping time. Results are provided by the [`getpeerinfo` RPC](../api/remote-procedure-calls-network.md#getpeerinfo) pingtime and pingwait fields as decimal seconds. The P2P [`ping` message](../reference/p2p-network-control-messages.md#ping) is handled in a queue with all other commands, so it measures processing backlog, not just network ping.
 * [SetBan](../api/remote-procedure-calls-network.md#setban): attempts add or remove a IP/Subnet from the banned list.
 * [SetNetworkActive](../api/remote-procedure-calls-network.md#setnetworkactive): disables/enables all P2P network activity.
@@ -126,31 +126,31 @@ These RPCs are all Dash-specific and not found in Bitcoin Core
 * [CombineRawTransaction](../api/remote-procedure-calls-raw-transactions.md#combinerawtransaction): combine multiple partially signed transactions into one transaction. _New in Dash Core 0.15.0_
 * [ConvertToPSBT](../api/remote-procedure-calls-raw-transactions.md#converttopsbt): converts a network serialized transaction to a PSBT. _New in Dash Core 18.0.0_
 * [CreatePSBT](../api/remote-procedure-calls-raw-transactions.md#createpsbt): creates a transaction in the Partially Signed Transaction (PST) format. _New in Dash Core 18.0.0_
-* [GetAssetUnlockStatuses](../api/remote-procedure-calls-raw-transactions.md#getassetunlockstatuses): returns the status of the provided Asset Unlock indexes at the tip of the chain or at a particular block height if specified. **New in Dash Core 20.1.0**
+* [GetAssetUnlockStatuses](../api/remote-procedure-calls-raw-transactions.md#getassetunlockstatuses): returns the status of the provided Asset Unlock indexes at the tip of the chain or at a particular block height if specified. _New in Dash Core 20.1.0_
 * [CreateRawTransaction](../api/remote-procedure-calls-raw-transactions.md#createrawtransaction): creates an unsigned serialized transaction that spends a previous output to a new output with a P2PKH or P2SH address. The transaction is not stored in the wallet or transmitted to the network. _Updated in Dash Core 0.17.0_
 * [DecodePSBT](../api/remote-procedure-calls-raw-transactions.md#decodepsbt): returns a JSON object representing the serialized, base64-encoded partially signed Dash transaction. _New in Dash Core 18.0.0_
-* [DecodeRawTransaction](../api/remote-procedure-calls-raw-transactions.md#decoderawtransaction): decodes a serialized transaction hex string into a JSON object describing the transaction. **Updated in Dash Core 21.0.0**
-* [DecodeScript](../api/remote-procedure-calls-raw-transactions.md#decodescript): decodes a hex-encoded P2SH redeem script. **Updated in Dash Core 21.0.0**
+* [DecodeRawTransaction](../api/remote-procedure-calls-raw-transactions.md#decoderawtransaction): decodes a serialized transaction hex string into a JSON object describing the transaction. **_Updated in Dash Core 21.0.0_**
+* [DecodeScript](../api/remote-procedure-calls-raw-transactions.md#decodescript): decodes a hex-encoded P2SH redeem script. **_Updated in Dash Core 21.0.0_**
 * [FinalizePSBT](../api/remote-procedure-calls-raw-transactions.md#finalizepsbt): finalizes the inputs of a PSBT. The PSBT produces a network serialized transaction if the transaction is fully signed. _New in Dash Core 18.0.0_
-* [FundRawTransaction](../api/remote-procedure-calls-raw-transactions.md#fundrawtransaction): adds inputs to a transaction until it has enough in value to meet its out value. **Updated in Dash Core 21.0.0**
-* [GetRawTransaction](../api/remote-procedure-calls-raw-transactions.md#getrawtransaction): gets a hex-encoded serialized transaction or a JSON object describing the transaction. By default, Dash Core only stores complete transaction data for UTXOs and your own transactions, so the RPC may fail on historic transactions unless you use the non-default `txindex=1` in your Dash Core startup settings. **Updated in Dash Core 21.0.0**
-* [GetRawTransactionMulti](../api/remote-procedure-calls-raw-transactions.md#getrawtransactionmulti): gets hex-encoded serialized transactions or a JSON object describing the multiple transactions. **Added in Dash Core 20.1.0**
-* [GetTxChainlocks](../api/remote-procedure-calls-raw-transactions.md#gettxchainlocks): returns the block height each transaction was mined at and whether it is ChainLocked or not. **Updated in Dash Core 20.1.0**
+* [FundRawTransaction](../api/remote-procedure-calls-raw-transactions.md#fundrawtransaction): adds inputs to a transaction until it has enough in value to meet its out value. **_Updated in Dash Core 21.0.0_**
+* [GetRawTransaction](../api/remote-procedure-calls-raw-transactions.md#getrawtransaction): gets a hex-encoded serialized transaction or a JSON object describing the transaction. By default, Dash Core only stores complete transaction data for UTXOs and your own transactions, so the RPC may fail on historic transactions unless you use the non-default `txindex=1` in your Dash Core startup settings. **_Updated in Dash Core 21.0.0_**
+* [GetRawTransactionMulti](../api/remote-procedure-calls-raw-transactions.md#getrawtransactionmulti): gets hex-encoded serialized transactions or a JSON object describing the multiple transactions. _New in Dash Core 20.1.0_
+* [GetTxChainlocks](../api/remote-procedure-calls-raw-transactions.md#gettxchainlocks): returns the block height each transaction was mined at and whether it is ChainLocked or not. _Updated in Dash Core 20.1.0_
 * [JoinPSBTs](../api/remote-procedure-calls-raw-transactions.md#joinpsbts): joins multiple distinct PSBTs with different inputs and outputs into one PSBT with inputs and outputs from all of the PSBTs.
 * [SendRawTransaction](../api/remote-procedure-calls-raw-transactions.md#sendrawtransaction): validates a transaction and broadcasts it to the peer-to-peer network. _Updated in Dash Core 0.15.0_
 * [SignRawTransactionWithKey](../api/remote-procedure-calls-raw-transactions.md#signrawtransactionwithkey): signs a transaction in the serialized transaction format using private keys provided in the call. _New in Dash Core 0.17.0_
-* [TestMempoolAccept](../api/remote-procedure-calls-raw-transactions.md#testmempoolaccept): returns the results of mempool acceptance tests indicating if raw transaction (serialized, hex-encoded) would be accepted by mempool. **Updated in Dash Core 20.1.0**
+* [TestMempoolAccept](../api/remote-procedure-calls-raw-transactions.md#testmempoolaccept): returns the results of mempool acceptance tests indicating if raw transaction (serialized, hex-encoded) would be accepted by mempool. _Updated in Dash Core 20.1.0_
 * [UTXOUpdatePSBT](../api/remote-procedure-calls-raw-transactions.md#testmempoolaccept): updates a PSBT with data from output descriptors, UTXOs retrieved from the UTXO set or the mempool. _Updated in Dash Core 18.1.0_
 
 ## [Utility RPCs](../api/remote-procedure-calls-util.md)
 
-* [CreateMultiSig](../api/remote-procedure-calls-util.md#createmultisig): creates a P2SH multi-signature address. **Updated in Dash Core 20.0.0**
+* [CreateMultiSig](../api/remote-procedure-calls-util.md#createmultisig): creates a P2SH multi-signature address. _Updated in Dash Core 20.0.0_
 * [DeriveAddresses](../api/remote-procedure-calls-util.md#deriveaddresses): derives one or more addresses corresponding to an output descriptor. _Updated in Dash Core 18.1.0_
 * [EstimateSmartFee](../api/remote-procedure-calls-util.md#estimatesmartfee): estimates the transaction fee per kilobyte that needs to be paid for a transaction to begin confirmation within a certain number of blocks and returns the number of blocks for which the estimate is valid. _Updated in Dash Core 0.15.0_
 * [GetDescriptorInfo](../api/remote-procedure-calls-util.md#getdescriptorinfo): analyses a descriptor. _New in Dash Core 18.0.0_
-* [GetIndexInfo](../api/remote-procedure-calls-util.md#getindexinfo): returns the status of one or all available indices currently running in the node. **New in Dash Core 20.0.0**
+* [GetIndexInfo](../api/remote-procedure-calls-util.md#getindexinfo): returns the status of one or all available indices currently running in the node. _New in Dash Core 20.0.0_
 * [SignMessageWithPrivKey](../api/remote-procedure-calls-util.md#signmessagewithprivkey): signs a message with a given private key.  _New in Dash Core 0.12.3_
-* [ValidateAddress](../api/remote-procedure-calls-util.md#validateaddress): returns information about the given Dash address. **Updated in Dash Core 20.1.0**
+* [ValidateAddress](../api/remote-procedure-calls-util.md#validateaddress): returns information about the given Dash address. _Updated in Dash Core 20.1.0_
 * [VerifyMessage](../api/remote-procedure-calls-util.md#verifymessage): verifies a signed message.
 
 ## [Wallet RPCs](../api/remote-procedure-calls-wallet.md)
@@ -159,14 +159,14 @@ These RPCs are all Dash-specific and not found in Bitcoin Core
 
 * [AbandonTransaction](../api/remote-procedure-calls-wallet.md#abandontransaction): marks an in-wallet transaction and all its in-wallet descendants as abandoned. This allows their inputs to be respent.
 * [AbortRescan](../api/remote-procedure-calls-wallet.md#abortrescan): stops current wallet rescan. _New in Dash Core 0.15.0_
-* [AddMultiSigAddress](../api/remote-procedure-calls-wallet.md#addmultisigaddress): adds a P2SH multisig address to the wallet. **Updated in Dash Core 20.0.0**
+* [AddMultiSigAddress](../api/remote-procedure-calls-wallet.md#addmultisigaddress): adds a P2SH multisig address to the wallet. _Updated in Dash Core 20.0.0_
 * [BackupWallet](../api/remote-procedure-calls-wallet.md#backupwallet): safely copies `wallet.dat` to the specified file, which can be a directory or a path with filename.
-* [CreateWallet](../api/remote-procedure-calls-wallet.md#createwallet): creates and loads a new wallet. **Updated in Dash Core 21.0.0**
+* [CreateWallet](../api/remote-procedure-calls-wallet.md#createwallet): creates and loads a new wallet. **_Updated in Dash Core 21.0.0_**
 * [DumpHDInfo](../api/remote-procedure-calls-wallet.md#dumphdinfo): returns an object containing sensitive private info about this HD wallet New in Dash Core 0.12.2
 * [DumpPrivKey](../api/remote-procedure-calls-wallet.md#dumpprivkey): returns the wallet-import-format (WIP) private key corresponding to an address. (But does not remove it from the wallet.)
 * [DumpWallet](../api/remote-procedure-calls-wallet.md#dumpwallet): creates or overwrites a file with all wallet keys in a human-readable format. _Updated in Dash Core 0.17.0_
 * [EncryptWallet](../api/remote-procedure-calls-wallet.md#encryptwallet): encrypts the wallet with a passphrase.  This is only to enable encryption for the first time. After encryption is enabled, you will need to enter the passphrase to use private keys.
-* [GetAddressInfo](../api/remote-procedure-calls-wallet.md#getaddressinfo): returns information about the given Dash address. **Updated in Dash Core 21.0.0**
+* [GetAddressInfo](../api/remote-procedure-calls-wallet.md#getaddressinfo): returns information about the given Dash address. **_Updated in Dash Core 21.0.0_**
 * [GetAddressesByLabel](../api/remote-procedure-calls-wallet.md#getaddressesbylabel): returns a list of every address assigned to a particular label. _New in Dash Core 0.17.0_
 * [GetBalance](../api/remote-procedure-calls-wallet.md#getbalance): gets the balance in decimal dash across all accounts or for a particular account. _Updated in Dash Core 18.1.0_
 * [GetBalances](../api/remote-procedure-calls-wallet.md#getbalances): returns an object with all balances denominated in DASH. _Updated in Dash Core 18.2.0_
@@ -174,12 +174,12 @@ These RPCs are all Dash-specific and not found in Bitcoin Core
 * [GetRawChangeAddress](../api/remote-procedure-calls-wallet.md#getrawchangeaddress): returns a new Dash address for receiving change. This is for use with raw transactions, not normal use.
 * [GetReceivedByAddress](../api/remote-procedure-calls-wallet.md#getreceivedbyaddress): returns the total amount received by the specified address in transactions with the specified number of confirmations. It does not count coinbase transactions. _Updated in Dash Core 0.13.0_
 * [GetReceivedByLabel](../api/remote-procedure-calls-wallet.md#getreceivedbylabel): returns the list of addresses assigned the specified label. _New in Dash Core 0.17.0_
-* [GetTransaction](../api/remote-procedure-calls-wallet.md#gettransaction): gets detailed information about an in-wallet transaction. **Updated in Dash Core 20.0.0**
+* [GetTransaction](../api/remote-procedure-calls-wallet.md#gettransaction): gets detailed information about an in-wallet transaction. _Updated in Dash Core 20.0.0_
 * [GetUnconfirmedBalance](../api/remote-procedure-calls-wallet.md#getunconfirmedbalance): returns the wallet's total unconfirmed balance.
-* [GetWalletInfo](../api/remote-procedure-calls-wallet.md#getwalletinfo): provides information about the wallet.  **Updated in Dash Core 20.0.0**
+* [GetWalletInfo](../api/remote-procedure-calls-wallet.md#getwalletinfo): provides information about the wallet.  _Updated in Dash Core 20.0.0_
 * [ImportAddress](../api/remote-procedure-calls-wallet.md#importaddress): adds an address or pubkey script to the wallet without the associated private key, allowing you to watch for transactions affecting that address or pubkey script without being able to spend any of its outputs.
 * [ImportElectrumWallet](../api/remote-procedure-calls-wallet.md#importelectrumwallet): imports keys from an Electrum wallet export file (.csv or .json) New in Dash Core 0.12.1
-* [ImportDescriptors](../api/remote-procedure-calls-wallet.md#importdescriptors): imports multiple descriptors into the wallet. **New in Dash Core 21.0.0**
+* [ImportDescriptors](../api/remote-procedure-calls-wallet.md#importdescriptors): imports multiple descriptors into the wallet. **_New in Dash Core 21.0.0_**
 * [ImportMulti](../api/remote-procedure-calls-wallet.md#importmulti): imports addresses or scripts (with private keys, public keys, or P2SH redeem scripts) and optionally performs the minimum necessary rescan for all imports. _New in Dash Core 0.12.3_
 * [ImportPrivKey](../api/remote-procedure-calls-wallet.md#importprivkey): adds a private key to your wallet. The key should be formatted in the wallet import format created by the [`dumpprivkey` RPC](../api/remote-procedure-calls-wallet.md#dumpprivkey).
 * [ImportPrunedFunds](../api/remote-procedure-calls-wallet.md#importprunedfunds): imports funds without the need of a rescan. Meant for use with pruned wallets. _New in Dash Core 0.12.3_
@@ -188,13 +188,13 @@ These RPCs are all Dash-specific and not found in Bitcoin Core
 * [KeyPoolRefill](../api/remote-procedure-calls-wallet.md#keypoolrefill): fills the cache of unused pre-generated keys (the keypool).
 * [ListAddressBalances](../api/remote-procedure-calls-wallet.md#listaddressbalances): lists addresses of this wallet and their balances _New in Dash Core 0.12.3_
 * [ListAddressGroupings](../api/remote-procedure-calls-wallet.md#listaddressgroupings): lists groups of addresses that may have had their common ownership made public by common use as inputs in the same transaction or from being used as change from a previous transaction. _Updated in Dash Core 0.17.0_
-* [ListDescriptors](../api/remote-procedure-calls-wallet.md#listdescriptors): lists descriptors imported into a descriptor-enabled wallet. **New in Dash Core 21.0.0**
+* [ListDescriptors](../api/remote-procedure-calls-wallet.md#listdescriptors): lists descriptors imported into a descriptor-enabled wallet. **_New in Dash Core 21.0.0_**
 * [ListLabels](../api/remote-procedure-calls-wallet.md#listlabels): returns the list of all labels, or labels that are assigned to addresses with a specific purpose. _New in Dash Core 0.17.0_
 * [ListLockUnspent](../api/remote-procedure-calls-wallet.md#listlockunspent): returns a list of temporarily unspendable (locked) outputs.
 * [ListReceivedByAddress](../api/remote-procedure-calls-wallet.md#listreceivedbyaddress): lists the total number of dash received by each address. _Updated in Dash Core 0.17.0_
 * [ListReceivedByLabel](../api/remote-procedure-calls-wallet.md#listreceivedbylabel): lists the total number of dash received by each label. _New in Dash Core 0.17.0_
-* [ListSinceBlock](../api/remote-procedure-calls-wallet.md#listsinceblock): gets all transactions affecting the wallet which have occurred since a particular block, plus the header hash of a block at a particular depth. **Updated in Dash Core 20.0.0**
-* [ListTransactions](../api/remote-procedure-calls-wallet.md#listtransactions): returns the most recent transactions that affect the wallet. **Updated in Dash Core 20.0.0**
+* [ListSinceBlock](../api/remote-procedure-calls-wallet.md#listsinceblock): gets all transactions affecting the wallet which have occurred since a particular block, plus the header hash of a block at a particular depth. _Updated in Dash Core 20.0.0_
+* [ListTransactions](../api/remote-procedure-calls-wallet.md#listtransactions): returns the most recent transactions that affect the wallet. _Updated in Dash Core 20.0.0_
 * [ListUnspent](../api/remote-procedure-calls-wallet.md#listunspent): returns an array of unspent transaction outputs belonging to this wallet. _Updated in Dash Core 18.1.0_
 * [ListWalletDir](../api/remote-procedure-calls-wallet.md#listwalletdir): returns a list of wallets in the wallet directory. _New in Dash Core 18.0.0_
 * [ListWallets](../api/remote-procedure-calls-wallet.md#listwallets): returns a list of currently loaded wallets. _New in Dash Core 0.15.0_
@@ -206,7 +206,7 @@ These RPCs are all Dash-specific and not found in Bitcoin Core
 * [Send](../api/remote-procedure-calls-wallet.md#send): sends a transaction with specified outputs. **Updated in Dash Core 22.0.0**
 * [SendMany](../api/remote-procedure-calls-wallet.md#sendmany): creates and broadcasts a transaction which sends outputs to multiple addresses. **Updated in Dash Core 22.0.0**
 * [SendToAddress](../api/remote-procedure-calls-wallet.md#sendtoaddress): spends an amount to a given address. **Updated in Dash Core 22.0.0**
-* [SetHDSeed](../api/remote-procedure-calls-wallet.md#sethdseed): sets or generates a new HD wallet seed **New in Dash Core 21.0.0**
+* [SetHDSeed](../api/remote-procedure-calls-wallet.md#sethdseed): sets or generates a new HD wallet seed **_New in Dash Core 21.0.0_**
 * [SetLabel](../api/remote-procedure-calls-wallet.md#setlabel): sets the label associated with the given address.
 * [SetCoinJoinAmount](../api/remote-procedure-calls-wallet.md#setcoinjoinamount): sets the amount of DASH to be processed _New in Dash Core 0.13.0_
 * [SetCoinJoinRounds](../api/remote-procedure-calls-wallet.md#setcoinjoinrounds): sets the number of rounds to use _New in Dash Core 0.13.0_
@@ -214,15 +214,15 @@ These RPCs are all Dash-specific and not found in Bitcoin Core
 * [SetWalletFlag](../api/remote-procedure-calls-wallet.md#setwalletflag): changes the state of the given wallet flag for a wallet.
 * [SignMessage](../api/remote-procedure-calls-wallet.md#signmessage): signs a message with the private key of an address.
 * [SignRawTransactionWithWallet](../api/remote-procedure-calls-wallet.md#signrawtransactionwithwallet): signs a transaction in the serialized transaction format using private keys found in the wallet. _New in Dash Core 0.17.0_
-* [UnloadWallet](../api/remote-procedure-calls-wallet.md#unloadwallet): unloads the wallet referenced by the request endpoint otherwise unloads the wallet specified in the argument. **Updated in Dash Core 20.0.0**
+* [UnloadWallet](../api/remote-procedure-calls-wallet.md#unloadwallet): unloads the wallet referenced by the request endpoint otherwise unloads the wallet specified in the argument. _Updated in Dash Core 20.0.0_
 * [UpgradeToHD](../api/remote-procedure-calls-wallet.md#upgradetohd): upgrades non-HD wallets to HD. _New in Dash Core 0.17.0_
-* [UpgradeWallet](../api/remote-procedure-calls-wallet.md#upgradewallet): upgrades wallet version. **Updated in Dash Core 21.0.0**
-* [WalletCreateFundedPSBT](../api/remote-procedure-calls-wallet.md#walletcreatefundedpsbt): creates and funds a transaction in the Partially Signed Transaction (PST) format. Inputs will be added if supplied inputs are not enough. **Updated in Dash Core 21.0.0**
+* [UpgradeWallet](../api/remote-procedure-calls-wallet.md#upgradewallet): upgrades wallet version. **_Updated in Dash Core 21.0.0_**
+* [WalletCreateFundedPSBT](../api/remote-procedure-calls-wallet.md#walletcreatefundedpsbt): creates and funds a transaction in the Partially Signed Transaction (PST) format. Inputs will be added if supplied inputs are not enough. **_Updated in Dash Core 21.0.0_**
 * [WalletLock](../api/remote-procedure-calls-wallet.md#walletlock): removes the wallet encryption key from memory, locking the wallet. After calling this method, you will need to call `walletpassphrase` again before being able to call any methods which require the wallet to be unlocked.
 * [WalletPassphrase](../api/remote-procedure-calls-wallet.md#walletpassphrase): stores the wallet decryption key in memory for the indicated number of seconds. Issuing the `walletpassphrase` command while the wallet is already unlocked will set a new unlock time that overrides the old one.
 * [WalletPassphraseChange](../api/remote-procedure-calls-wallet.md#walletpassphrasechange): changes the wallet passphrase from 'old passphrase' to 'new passphrase'.
 * [WalletProcessPSBT](../api/remote-procedure-calls-wallet.md#walletprocesspsbt): updates a PSBT with input information from a wallet and then allows the signing of inputs. _Updated in Dash Core 18.2.0_
-* [WipeWalletTxes](../api/remote-procedure-calls-wallet.md#wipewallettxes): wipes wallet transactions. **_New in Dash Core 19.3.0_**
+* [WipeWalletTxes](../api/remote-procedure-calls-wallet.md#wipewallettxes): wipes wallet transactions. _New in Dash Core 19.3.0_
 
 ## [Wallet RPCs (Deprecated)](../api/remote-procedure-calls-wallet-deprecated.md)
 

--- a/docs/api/remote-procedure-call-quick-reference.md
+++ b/docs/api/remote-procedure-call-quick-reference.md
@@ -235,3 +235,7 @@ These RPCs are all Dash-specific and not found in Bitcoin Core
 ## [Removed RPCs](../api/remote-procedure-calls-removed.md)
 
 * [GObject vote-conf](../api/remote-procedure-calls-removed.md#gobject-vote-conf): **was removed in Dash Core 20.0.0**
+* [Protx Register HPMN](../api/remote-procedure-calls-evo.md#protx-register-evo): **was removed in Dash Core 22.0.0**
+* [Protx Register Fund HPMN](../api/remote-procedure-calls-evo.md#protx-register-fund-evo): **was removed in Dash Core 22.0.0**
+* [Protx Register Prepare HPMN](../api/remote-procedure-calls-evo.md#protx-register-prepare-evo): **was removed in Dash Core 22.0.0**
+* [Protx Update Service HPMN](../api/remote-procedure-calls-evo.md#protx-update-service-evo): **was removed in Dash Core 22.0.0**

--- a/docs/api/remote-procedure-call-quick-reference.md
+++ b/docs/api/remote-procedure-call-quick-reference.md
@@ -113,7 +113,7 @@ These RPCs are all Dash-specific and not found in Bitcoin Core
 * [GetNetTotals](../api/remote-procedure-calls-network.md#getnettotals): returns information about network traffic, including bytes in, bytes out, and the current time.
 * [GetNetworkInfo](../api/remote-procedure-calls-network.md#getnetworkinfo): returns information about the node's connection to the network. **Updated in Dash Core 21.0.0**
 * [GetNodeAddresses](../api/remote-procedure-calls-network.md#getnodeaddresses): returns the known addresses which can potentially be used to find new nodes in the network. **Updated in Dash Core 21.0.0**
-* [GetPeerInfo](../api/remote-procedure-calls-network.md#getpeerinfo): returns data about each connected network node. **Updated in Dash Core 21.0.0**
+* [GetPeerInfo](../api/remote-procedure-calls-network.md#getpeerinfo): returns data about each connected network node. **Updated in Dash Core 22.0.0**
 * [ListBanned](../api/remote-procedure-calls-network.md#listbanned): lists all banned IPs/Subnets. **Updated in Dash Core 21.0.0**
 * [Ping](../api/remote-procedure-calls-network.md#ping): sends a P2P ping message to all connected nodes to measure ping time. Results are provided by the [`getpeerinfo` RPC](../api/remote-procedure-calls-network.md#getpeerinfo) pingtime and pingwait fields as decimal seconds. The P2P [`ping` message](../reference/p2p-network-control-messages.md#ping) is handled in a queue with all other commands, so it measures processing backlog, not just network ping.
 * [SetBan](../api/remote-procedure-calls-network.md#setban): attempts add or remove a IP/Subnet from the banned list.

--- a/docs/api/remote-procedure-call-quick-reference.md
+++ b/docs/api/remote-procedure-call-quick-reference.md
@@ -81,7 +81,7 @@ These RPCs are all Dash-specific and not found in Bitcoin Core
 
 * [BLS](../api/remote-procedure-calls-evo.md#bls): provides a set of commands to execute BLS-related actions. **_Updated in Dash Core 19.0.0_**
 * [ProTx](../api/remote-procedure-calls-evo.md#protx): provides a set of commands to execute ProTx related actions. **Updated in Dash Core 20.1.0**
-* [Quorum](../api/remote-procedure-calls-evo.md#quorum): provides a set of commands for quorums (LLMQs). **Updated in Dash Core 20.1.0**
+* [Quorum](../api/remote-procedure-calls-evo.md#quorum): provides a set of commands for quorums (LLMQs). **Updated in Dash Core 22.0.0**
 * [SubmitChainLock](../api/remote-procedure-calls-evo.md#submitchainlock): allows the submission of a ChainLock signature. **New in Dash Core 20.1.0**
 * [VerifyChainLock](../api/remote-procedure-calls-evo.md#verifychainlock): tests if a quorum signature is valid for a ChainLock. _New in Dash Core 0.17.0_
 * [VerifyISLock](../api/remote-procedure-calls-evo.md#verifyislock): tests if a quorum signature is valid for an InstantSend lock. _New in Dash Core 0.17.0_

--- a/docs/api/remote-procedure-call-quick-reference.md
+++ b/docs/api/remote-procedure-call-quick-reference.md
@@ -70,7 +70,7 @@ These RPCs are all Dash-specific and not found in Bitcoin Core
 * [GetGovernanceInfo](../api/remote-procedure-calls-dash.md#getgovernanceinfo): returns an object containing governance parameters. **Updated in Dash Core 20.0.0**
 * [GetSuperblockBudget](../api/remote-procedure-calls-dash.md#getsuperblockbudget): returns the absolute maximum sum of superblock payments allowed.
 * [GObject](../api/remote-procedure-calls-dash.md#gobject): provides a set of commands for managing governance objects and displaying information about them. **Updated in Dash Core 20.0.0**
-* [Masternode](../api/remote-procedure-calls-dash.md#masternode): provides a set of commands for managing masternodes and displaying information about them. **_Updated in Dash Core 19.2.0_**
+* [Masternode](../api/remote-procedure-calls-dash.md#masternode): provides a set of commands for managing masternodes and displaying information about them. **Updated in Dash Core 22.0.0**
 * [MasternodeList](../api/remote-procedure-calls-dash.md#masternodelist): returns a list of masternodes in different modes. **Updated in Dash Core 20.0.0**
 * [MnSync](../api/remote-procedure-calls-dash.md#mnsync): returns the sync status, updates to the next step or resets it entirely. _Updated in Dash Core 0.14.0_
 * [Spork](../api/remote-procedure-calls-dash.md#spork): shows information about the current state of sporks. _Updated in Dash Core 18.1.0_

--- a/docs/api/remote-procedure-calls-dash.md
+++ b/docs/api/remote-procedure-calls-dash.md
@@ -1193,6 +1193,44 @@ dash-cli -testnet gobject vote-many \
 
 The [`masternode` RPC](#masternode) provides a set of commands for managing masternodes and displaying information about them.
 
+### Masternode Connect
+
+The [`masternode connect` RPC](#masternode-connect) initiates a connection to a specified masternode address, with optional support for the BIP324 v2 transport protocol.
+
+_Parameter #1---the address of the masternode_
+
+| Name      | Type   | Presence                | Description |
+| --------- | ------ | ----------------------- | ----------- |
+| address   | string | Required<br>(exactly 1) | The IP address and port of the masternode to connect to (e.g., `192.168.1.100:19999`) |
+
+_Parameter #2---transport protocol options_
+
+| Name         | Type    | Presence             | Description |
+| ------------ | ------- | -------------------- | ----------- |
+| v2transport  | bool    | Optional<br>(0 or 1) | Set to `true` to attempt connection using the BIP324 v2 transport protocol. Defaults to `false`. |
+
+_Result---connection status_
+
+| Name         | Type    | Presence                | Description |
+| ------------ | ------- | ----------------------- | ----------- |
+| `result`     | string  | Required<br>(exactly 1) | Command return status |
+
+*Example from Dash Core 22.0.0*
+
+Connect to a masternode at address `192.168.1.100` using the default transport protocol:
+
+```bash
+dash-cli masternode connect "192.168.1.100:19999"
+```
+
+Result:
+
+```text
+successfully connected
+```
+
+*See also: none*
+
 ### Masternode Count
 
 The `masternode count` RPC prints the number of all known masternodes.

--- a/docs/api/remote-procedure-calls-evo.md
+++ b/docs/api/remote-procedure-calls-evo.md
@@ -1401,12 +1401,6 @@ ec66f97568727a9e5188acb3ccf680086ae11217236efcccd67b0b72e83c79a043d6c6d064378fdd
 47d9401e0a569a5488728e09542d0545ab56f8249a4b21e03445fa411e
 ```
 
-### ProTx Register HPMN
-
-:::{deprecated} 20.0.0
-The `protx *_hpmn` RPC commands were renamed in Dash Core 20.0.0 and can now be accessed as `protx *_evo` (e.g. `protx register_hpmn` is now `protx register_evo`).
-:::
-
 ### ProTx Register Fund Evo
 
 The `protx register_fund_evo` RPC creates, funds, and sends a ProTx to the network. The resulting transaction will move 4000 Dash to the address specified by `collateralAddress` and will then function as the collateral of your evonode. A few of the limitations you see in the arguments are temporary and might be lifted after DIP3 is fully deployed. Requires the wallet passphrase to be provide with the [`walletpassphrase` RPC](../api/remote-procedure-calls-wallet.md#walletpassphrase) if the wallet is encrypted.
@@ -1536,12 +1530,6 @@ c207ebd525793ccb43f60ce34a5cd5f4011976a9145a375814e9caf5b8575a8221be246457e5c5c2
 8d88ac45084a0f63d6f06767c941ffd5af4ed17ea0e28afa481e46b2bdbadbd8446c8c00\
 ```
 
-### ProTx Register Fund HPMN
-
-:::{deprecated} 20.0.0
-The `protx *_hpmn` RPC commands were renamed in Dash Core 20.0.0 and can now be accessed as `protx *_evo` (e.g. `protx register_hpmn` is now `protx register_evo`).
-:::
-
 ### ProTx Register Prepare Evo
 
 The `protx register_prepare_evo` RPC creates an unsigned ProTx and a message that must be signed externally with the private key that corresponds to `collateralAddress` to prove collateral ownership. The prepared transaction will also contain inputs and outputs to cover fees.
@@ -1648,12 +1636,6 @@ Result:
 }
 ```
 
-### ProTx Register Prepare HPMN
-
-:::{deprecated} 20.0.0
-The `protx *_hpmn` RPC commands were renamed in Dash Core 20.0.0 and can now be accessed as `protx *_evo` (e.g. `protx register_hpmn` is now `protx register_evo`).
-:::
-
 ### ProTx Update Service Evo
 
 The `protx update_service_evo` RPC creates and sends a ProUpServTx to the network. This will update the IP address and the Platform fields of an evonode. If this is done for an evonode that was PoSe-banned, the ProUpServTx will also revive this evonode.
@@ -1727,12 +1709,6 @@ Result:
 ```bash
 5b6cfa1bdd3c8b7e0b9550b9c4e809381f81a410bc7f241d3879dd736fd51270
 ```
-
-### ProTx Update Service HPMN
-
-:::{deprecated} 20.0.0
-The `protx *_hpmn` RPC commands were renamed in Dash Core 20.0.0 and can now be accessed as `protx *_evo` (e.g. `protx register_hpmn` is now `protx register_evo`).
-:::
 
 ### ProTx Register Submit
 

--- a/docs/api/remote-procedure-calls-evo.md
+++ b/docs/api/remote-procedure-calls-evo.md
@@ -2925,6 +2925,64 @@ Result:
 }
 ```
 
+### Quorum GetData
+
+The [`quorum getdata` RPC](../api/remote-procedure-calls-quorum.md#quorum-getdata) sends a [`qgetdata` message](../reference/p2p-network-quorum-messages.md#qgetdata) to a specified peer, requesting specific quorum-related data from that peer.
+
+_Parameter #1---the internal node ID_
+
+| Name     | Type   | Presence                | Description |
+|----------|--------|-------------------------|-------------|
+| `nodeId` | number | Required<br>(exactly 1) | The internal nodeId of the peer from which quorum data is requested |
+
+_Parameter #2---the LLMQ type_
+
+| Name      | Type   | Presence                | Description |
+|-----------|--------|-------------------------|-------------|
+| `llmqType`| number | Required<br>(exactly 1) | The LLMQ type associated with the quorum data being requested    |
+
+_Parameter #3---the quorum hash_
+
+| Name         | Type   | Presence                | Description |
+|--------------|--------|-------------------------|-------------|
+| `quorumHash` | string | Required<br>(exactly 1) | The quorum hash for the quorum data being requested          |
+
+_Parameter #4---the data mask_
+
+| Name        | Type   | Presence                | Description |
+|-------------|--------|-------------------------|-------------|
+| `dataMask`  | number | Required<br>(exactly 1) | Specifies the type of data requested. Possible values are:<br>`1` - Quorum verification vector<br>`2` - Encrypted contributions for member specified by `proTxHash` (`proTxHash` must be specified if this option is used)<br>`3` - Both (1 and 2) |
+
+_Parameter #5---the ProTxHash_
+
+| Name       | Type   | Presence                  | Description |
+|------------|--------|---------------------------|-------------|
+| `proTxHash`| string | Optional<br>(default="") | The ProTxHash for the contributions requested. Must be a member of the specified LLMQ. Cannot be specified if `dataMask` is set to `1`. Required if `dataMask` is set to `2`. |
+
+_Result---execution result_
+
+| Name                | Type            | Presence                | Description |
+|---------------------|-----------------|-------------------------|-------------|
+| `success`           | bool            | Required<br>(exactly 1) | Displays `true` if the data request was successful or `false` if it failed |
+
+_Example from Dash Core 22.0.0_
+
+Requesting the quorum verification vector from a peer with node ID `12` for a quorum of type `2`:
+
+```bash
+dash-cli quorum getdata 1 2 "000000822d2b1b311af360750b6448917f10d8b92d2ea2a7bbae221e859354f9" 1
+```
+
+Result:
+
+```text
+true
+```
+
+_See also_
+
+* [Quorum List](#quorum-list): displays a list of on-chain quorums.
+
 ### Quorum GetRecSig
 
 The `quorum getrecsig` RPC gets the recovered signature for a previous threshold-signing message request.

--- a/docs/api/remote-procedure-calls-evo.md
+++ b/docs/api/remote-procedure-calls-evo.md
@@ -2927,7 +2927,7 @@ Result:
 
 ### Quorum GetData
 
-The [`quorum getdata` RPC](../api/remote-procedure-calls-quorum.md#quorum-getdata) sends a [`qgetdata` message](../reference/p2p-network-quorum-messages.md#qgetdata) to a specified peer, requesting specific quorum-related data from that peer.
+The [`quorum getdata` RPC](#quorum-getdata) sends a [`qgetdata` message](../reference/p2p-network-quorum-messages.md#qgetdata) to a specified peer, requesting specific quorum-related data from that peer.
 
 _Parameter #1---the internal node ID_
 

--- a/docs/api/remote-procedure-calls-network.md
+++ b/docs/api/remote-procedure-calls-network.md
@@ -12,20 +12,26 @@ The [`addnode` RPC](../api/remote-procedure-calls-network.md#addnode) attempts t
 
 *Parameter #1---hostname/IP address and port of node to add or remove*
 
-| Name   | Type   | Presence                | Description                                                       |
-| ------ | ------ | ----------------------- | ----------------------------------------------------------------- |
+| Name   | Type   | Presence                | Description |
+| ------ | ------ | ----------------------- | ----------- |
 | `node` | string | Required<br>(exactly 1) | The node to add as a string in the form of `<IP address>:<port>`. |
 
 *Parameter #2---whether to add or remove the node, or to try only once to connect*
 
-| Name      | Type   | Presence                | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
-| --------- | ------ | ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Name      | Type   | Presence                | Description |
+| --------- | ------ | ----------------------- | ----------- |
 | `command` | string | Required<br>(exactly 1) | What to do with the IP address above.  Options are:<br>• `add` to add a node to the addnode list.  Up to 8 nodes can be added additional to the default 8 nodes. Not limited by `-maxconnections`<br>• `remove` to remove a node from the list.  If currently connected, this will disconnect immediately<br>• `onetry` to immediately attempt connection to the node even if the outgoing connection slots are full; this will only attempt the connection once |
+
+*Parameter #3---v2 transport*
+
+| Name   | Type   | Presence                | Description |
+| ------ | ------ | ----------------------- | ----------- |
+| `v2transport` | bool | Optional<br>(0 or1) | Attempt to connect using BIP324 v2 transport protocol (ignored for `remove` command). Default=set by `-v2transport` option. |
 
 _Result---`null` plus error on failed remove_
 
-| Name     | Type | Presence                | Description                                                                                                                                                                                                                                             |
-| -------- | ---- | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Name     | Type | Presence                | Description |
+| -------- | ---- | ----------------------- | ----------- |
 | `result` | null | Required<br>(exactly 1) | Always JSON `null` whether the node was added, removed, tried-and-connected, or tried-and-not-connected.  The JSON-RPC error field will be set only if you try adding a node that was already added or removing a node that is not on the addnodes list |
 
 *Example from Dash Core 0.12.2*

--- a/docs/api/remote-procedure-calls-network.md
+++ b/docs/api/remote-procedure-calls-network.md
@@ -564,8 +564,10 @@ The [`getpeerinfo` RPC](../api/remote-procedure-calls-network.md#getpeerinfo) re
 | → →<br>`bytesrecv_per_msg` | string : <br>object | Required<br>(exactly 1) | *Added in Bitcoin Core 0.13.0*<br><br>Information about total received bytes aggregated by message type |
 | → → →<br>Message Type | number (int) | Required<br>(1 or more) | Total received bytes aggregated by message type. One field for every used message type |
 | `connection_type` | string | Required<br>(exactly 1) | **Added in Dash Core 20.1.0**<br>Type of connection:<br>outbound-full-relay, block-relay-only, inbound, manual, addr-fetch, feeler.<br>Describes how the connection was established. Set to `true` if this node was added via the [`addnode` RPC](../api/remote-procedure-calls-network.md#addnode).<br>**Note: This output is subject to change in future releases as connection behaviors are refined.** |
+| `transport_protocol_type`| string | Optional<br>(0 or 1) | **Added in Dash Core 22.0.0**<br>The transport protocol type:<br>`detecting` - peer could be v1 or v2<br>`v1` - plaintext transport protocol<br>`v2` - BIP324 encrypted transport protocol |
+| `session_id` | string | Optional<br>(0 or 1) | **Added in Dash Core 22.0.0**<br>The session ID for this connection, or "" if there is none ("v2" transport protocol only). |
 
-*Example from Dash Core 21.0.0*
+*Example from Dash Core 22.0.0*
 
 ```bash
 dash-cli -testnet getpeerinfo
@@ -599,20 +601,20 @@ Result (edited to show only a single entry, with IP addresses changed to
     "timeoffset": 0,
     "pingtime": 0.105995,
     "minping": 0.095181,
-    "version": 70232,
-    "subver": "/Dash Core:21.0.0(dcg-masternode-7)/",
+    "version": 70233,
+    "subver": "/Dash Core:21.1.0(dcg-masternode-7)/",
     "inbound": false,
     "bip152_hb_to": false,
     "bip152_hb_from": false,
     "masternode": false,
-    "startingheight": 1022323,
-    "synced_headers": 1022323,
-    "synced_blocks": 1022323,
+    "startingheight": 1131692,
+    "synced_headers": 1131804,
+    "synced_blocks": 1131804,
     "inflight": [
     ],
-    "relaytxes": false,
-    "addr_relay_enabled": false,
-    "addr_processed": 0,
+    "relaytxes": true,
+    "addr_relay_enabled": true,
+    "addr_processed": 519,
     "addr_rate_limited": 0,
     "permissions": [
     ],
@@ -651,7 +653,9 @@ Result (edited to show only a single entry, with IP addresses changed to
       "verack": 24,
       "version": 180
     },
-    "connection_type": "block-relay-only"
+    "connection_type": "outbound-full-relay",
+    "transport_protocol_type": "v1",
+    "session_id": ""
   }
 ]
 ```

--- a/docs/api/remote-procedure-calls-removed.md
+++ b/docs/api/remote-procedure-calls-removed.md
@@ -61,3 +61,45 @@ dash-cli -testnet gobject vote-conf \
   }
 }
 ```
+
+## Protx
+
+### ProTx Register HPMN
+
+:::{attention}
+Removed in Dash Core 22.0.0
+:::
+
+The `protx *_hpmn` RPC commands were renamed and deprecated in Dash Core 20.0.0. They can now be accessed as `protx *_evo` (e.g., `protx register_hpmn` is now [`protx register_evo`](../api/remote-procedure-calls-evo.md#protx-register-evo)).
+
+**All `protx *_hpmn` RPC commands were removed in Dash Core 22.0.0.**
+
+### ProTx Register Fund HPMN
+
+:::{attention}
+Removed in Dash Core 22.0.0
+:::
+
+The `protx *_hpmn` RPC commands were renamed and deprecated in Dash Core 20.0.0. They can now be accessed as `protx *_evo` (e.g., `protx register_hpmn` is now [`protx register_evo`](../api/remote-procedure-calls-evo.md#protx-register-evo)).
+
+**All `protx *_hpmn` RPC commands were removed in Dash Core 22.0.0.**
+
+### ProTx Register Prepare HPMN
+
+:::{attention}
+Removed in Dash Core 22.0.0
+:::
+
+The `protx *_hpmn` RPC commands were renamed and deprecated in Dash Core 20.0.0. They can now be accessed as `protx *_evo` (e.g., `protx register_hpmn` is now [`protx register_evo`](../api/remote-procedure-calls-evo.md#protx-register-evo)).
+
+**All `protx *_hpmn` RPC commands were removed in Dash Core 22.0.0.**
+
+### ProTx Update Service HPMN
+
+:::{attention}
+Removed in Dash Core 22.0.0
+:::
+
+The `protx *_hpmn` RPC commands were renamed and deprecated in Dash Core 20.0.0. They can now be accessed as `protx *_evo` (e.g., `protx register_hpmn` is now [`protx register_evo`](../api/remote-procedure-calls-evo.md#protx-register-evo)).
+
+**All `protx *_hpmn` RPC commands were removed in Dash Core 22.0.0.**

--- a/docs/api/remote-procedure-calls-wallet.md
+++ b/docs/api/remote-procedure-calls-wallet.md
@@ -2781,7 +2781,13 @@ _Parameter #3---estimate_mode_
 | -------------- | ------ | -------------------- | ------------------------------------------------------------------------------------------------------------------------- |
 | estimate_mode  | string | Optional<br>(0 or 1) | The fee estimate mode. Must be one of: `unset`, `economical`, `conservative`, `DASH/kB`, `duff/B`. Default is `unset`.   |
 
-_Parameter #4---Options_
+_Parameter #4---Fee rate_
+
+| Name     | Type    | Presence                | Description |
+| -------- | ------- | ----------------------- | ----------- |
+| fee_rate | number or string | Optional<br>(0 or 1)    | **Added in Dash Core 22.0.0**<br>Specify a fee rate in duffs/B (default=not set, fall back to wallet fee estimation). |
+
+_Parameter #5---Options_
 
 | Name                        | Type               | Presence                | Description                                         |
 | --------------------------- | ------------------ | ----------------------- | --------------------------------------------------- |
@@ -2901,10 +2907,16 @@ _Parameter #10---fee estimate mode_
 | ---- | ---- | -------- | ----------- |
 | `estimate_mode` | string | Optional<br>(0 or 1) | The fee estimate mode, must be one of:<br>`unset`<br>`economical`<br>`conservative`<br>`DASH/kB`<br>`duff/B` |
 
-_Parameter #11---verbose_
+_Parameter #11---fee rate_
 
-| Name    | Type    | Presence                | Description                                                |
-| ------- | ------- | ----------------------- | ---------------------------------------------------------- |
+| Name     | Type    | Presence                | Description |
+| -------- | ------- | ----------------------- | ----------- |
+| `fee_rate` | number or string | Optional<br>(0 or 1)    | **Added in Dash Core 22.0.0**<br>Specify a fee rate in duffs/B (default=not set, fall back to wallet fee estimation). |
+
+_Parameter #12---verbose_
+
+| Name    | Type    | Presence                | Description |
+| ------- | ------- | ----------------------- | ----------- |
 | verbose | boolean | Optional<br>(0 or 1)    | If `true`, return extra information about the transaction. Default is `false` |
 
 _Result---execution result_
@@ -3047,10 +3059,16 @@ _Parameter #10---avoids partial respends_
 | ------------- | ------- | -------------------- | ----------------------------------------------------------------------------------------------------------------------- |
 | `avoid_reuse` | boolean | Optional<br>(0 or 1) | Avoid spending from dirty addresses; addresses are considered dirty if they have previously been used in a transaction. |
 
-_Parameter #11---verbose_
+_Parameter #11---fee rate_
 
-| Name    | Type    | Presence                | Description                                                |
-| ------- | ------- | ----------------------- | ---------------------------------------------------------- |
+| Name     | Type    | Presence                | Description |
+| -------- | ------- | ----------------------- | ----------- |
+| `fee_rate` | number or string | Optional<br>(0 or 1)    | **Added in Dash Core 22.0.0**<br>Specify a fee rate in duffs/B (default=not set, fall back to wallet fee estimation). |
+
+_Parameter #12---verbose_
+
+| Name    | Type    | Presence                | Description |
+| ------- | ------- | ----------------------- | ----------- |
 | verbose | boolean | Optional<br>(0 or 1)    | If `true`, return extra information about the transaction. Default is `false` |
 
 _Result---execution result_


### PR DESCRIPTION
- [x] Removed previously deprecated protx commands
- [x] Updated send commands with fee_rate param
- [x] Added missing quorum getdata 
- [x] Added missing masternode connect
- [x] Update addnode
- [x] Update getpeerinfo

<!-- Replace -->
Preview build: https://dash-docs--123.org.readthedocs.build/projects/core/en/123/
<!-- Replace -->
