### PR TITLE
feat: add alternate analytics config

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -40,6 +40,7 @@ extensions = [
   'sphinx.ext.autodoc',
   'sphinx_copybutton',
   'sphinx_design',
+  'sphinxcontrib.googleanalytics',
   'sphinx.ext.intersphinx',
 ]
 
@@ -156,6 +157,11 @@ html_context = {
     "github_version": "21.0.0",
     "doc_path": "",
 }
+
+# -- Google analytics config ----------------------------------------------
+
+googleanalytics_id = 'G-X6K8R91RDR'
+googleanalytics_enabled = True
 
 def setup(app):
     app.add_js_file('js/pydata-search-close.js')

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ Babel==2.12.1
 myst-parser==2.0.0
 pydata-sphinx-theme==0.14.4
 sphinx==7.2.6
+sphinxcontrib-googleanalytics==0.4
 sphinx-copybutton==0.5.2
 sphinx-hoverxref==1.3.0
 sphinx-multiproject==1.0.0rc1


### PR DESCRIPTION
Readthedocs removed their analytics integration (see https://github.com/readthedocs/readthedocs.org/issues/9530#issuecomment-2233541583). This PR introduces use of an addon to re-enable that capability.